### PR TITLE
Alert Manager: correctness fixes, utility reuse, and type cleanup

### DIFF
--- a/common/services/alerting/form_transforms.ts
+++ b/common/services/alerting/form_transforms.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Form → API payload transforms for alerting monitor creation.
+ *
+ * Pure functions with no React, coreRefs, or Node dependencies —
+ * safe to import from both client and server, and to unit-test in
+ * isolation.
+ */
+
+export interface LogsMonitorAction {
+  name: string;
+  notificationChannel: string;
+  message?: string;
+  subject?: string;
+}
+
+export interface LogsMonitorTrigger {
+  name: string;
+  severityLevel: string;
+  conditionOperator: string;
+  conditionValue: number;
+  suppressEnabled: boolean;
+  suppressExpiry: number;
+  suppressExpiryUnit: string;
+  actions: LogsMonitorAction[];
+}
+
+export interface LogsMonitorForm {
+  monitorName: string;
+  runEveryValue: number;
+  runEveryUnit: string;
+  selectedDatasource: string;
+  query: string;
+  triggers: LogsMonitorTrigger[];
+}
+
+export interface MetricsMonitorLabel {
+  key: string;
+  value: string;
+}
+
+export interface MetricsMonitorForm {
+  monitorName: string;
+  query: string;
+  operator: string;
+  thresholdValue: number;
+  forDuration: string;
+  labels: MetricsMonitorLabel[];
+  annotations: MetricsMonitorLabel[];
+}
+
+const UNIT_MAP: Record<string, string> = {
+  minute: 'MINUTES',
+  hour: 'HOURS',
+  day: 'DAYS',
+};
+
+const SEVERITY_MAP: Record<string, '1' | '2' | '3' | '4' | '5'> = {
+  critical: '1',
+  high: '2',
+  medium: '3',
+  low: '4',
+  info: '5',
+};
+
+const CONDITION_OPERATOR_MAP: Record<string, string> = {
+  is_greater_than: '>',
+  is_less_than: '<',
+  is_equal_to: '==',
+  is_greater_equal: '>=',
+  is_less_equal: '<=',
+  is_not_equal: '!=',
+};
+
+export function mapScheduleUnit(unit: string): string {
+  const lower = unit.toLowerCase().replace(/\(s\)$/, '');
+  return UNIT_MAP[lower] ?? 'MINUTES';
+}
+
+export function mapSeverityLevel(severity: string): '1' | '2' | '3' | '4' | '5' {
+  return SEVERITY_MAP[severity] ?? '3';
+}
+
+export function buildConditionScript(trigger: {
+  conditionOperator: string;
+  conditionValue: number;
+}): string {
+  const op = CONDITION_OPERATOR_MAP[trigger.conditionOperator] ?? '>';
+  return `ctx.results[0].hits.total.value ${op} ${trigger.conditionValue}`;
+}
+
+/**
+ * Parse a query string as JSON, falling back to a query_string wrapper
+ * so callers can pass either a raw DSL object or a freeform query.
+ */
+export function parseQueryPayload(query: string): Record<string, unknown> {
+  try {
+    return JSON.parse(query);
+  } catch {
+    return { query_string: { query } };
+  }
+}
+
+/** Build an OpenSearch Alerting monitor create payload from a logs form. */
+export function transformLogsFormToPayload(form: LogsMonitorForm): Record<string, unknown> {
+  return {
+    type: 'monitor',
+    name: form.monitorName,
+    enabled: true,
+    schedule: {
+      period: { interval: form.runEveryValue, unit: mapScheduleUnit(form.runEveryUnit) },
+    },
+    inputs: [
+      {
+        search: {
+          indices: [form.selectedDatasource],
+          query: { size: 0, query: parseQueryPayload(form.query) },
+        },
+      },
+    ],
+    triggers: form.triggers.map((t) => ({
+      name: t.name,
+      severity: mapSeverityLevel(t.severityLevel),
+      condition: {
+        script: { source: buildConditionScript(t), lang: 'painless' },
+      },
+      actions: t.actions.map((a) => ({
+        name: a.name,
+        destination_id: a.notificationChannel,
+        message_template: { source: a.message || '' },
+        subject_template: { source: a.subject || '' },
+        throttle_enabled: t.suppressEnabled,
+        throttle: t.suppressEnabled
+          ? { value: t.suppressExpiry, unit: mapScheduleUnit(t.suppressExpiryUnit) }
+          : undefined,
+      })),
+    })),
+  };
+}
+
+/** Build a Prometheus rule-group create payload from a metrics form. */
+export function transformMetricsFormToPayload(form: MetricsMonitorForm): Record<string, unknown> {
+  return {
+    name: form.monitorName,
+    rules: [
+      {
+        alert: form.monitorName,
+        expr: `${form.query} ${form.operator} ${form.thresholdValue}`,
+        for: form.forDuration,
+        labels: Object.fromEntries(
+          form.labels.filter((l) => l.key && l.value).map((l) => [l.key, l.value])
+        ),
+        annotations: Object.fromEntries(
+          form.annotations.filter((a) => a.key && a.value).map((a) => [a.key, a.value])
+        ),
+      },
+    ],
+  };
+}

--- a/common/types/alerting/types.ts
+++ b/common/types/alerting/types.ts
@@ -348,31 +348,48 @@ export interface PromRuleGroup {
 // Service interfaces
 // ============================================================================
 
-/** OpenSearch Alerting backend */
+/** OpenSearch Alerting backend.
+ *
+ * Implementations talk to the cluster through the caller-provided scoped
+ * `AlertingOSClient` (resolved via OSD's multi-data-source client factory).
+ * The datasource identity is already baked into that client, so the methods
+ * take the client directly rather than a `Datasource`.
+ */
 export interface OpenSearchBackend {
   readonly type: 'opensearch';
 
   // Monitors
-  getMonitors(ds: Datasource): Promise<OSMonitor[]>;
-  getMonitor(ds: Datasource, monitorId: string): Promise<OSMonitor | null>;
-  createMonitor(ds: Datasource, monitor: Omit<OSMonitor, 'id'>): Promise<OSMonitor>;
+  getMonitors(client: AlertingOSClient): Promise<OSMonitor[]>;
+  getMonitor(client: AlertingOSClient, monitorId: string): Promise<OSMonitor | null>;
+  createMonitor(client: AlertingOSClient, monitor: Omit<OSMonitor, 'id'>): Promise<OSMonitor>;
   updateMonitor(
-    ds: Datasource,
+    client: AlertingOSClient,
     monitorId: string,
     monitor: Partial<OSMonitor>
   ): Promise<OSMonitor | null>;
-  deleteMonitor(ds: Datasource, monitorId: string): Promise<boolean>;
-  runMonitor(ds: Datasource, monitorId: string, dryRun?: boolean): Promise<unknown>;
-  searchQuery(ds: Datasource, indices: string[], body: Record<string, unknown>): Promise<unknown>;
+  deleteMonitor(client: AlertingOSClient, monitorId: string): Promise<boolean>;
+  runMonitor(client: AlertingOSClient, monitorId: string, dryRun?: boolean): Promise<unknown>;
+  searchQuery(
+    client: AlertingOSClient,
+    indices: string[],
+    body: Record<string, unknown>
+  ): Promise<unknown>;
 
   // Alerts
-  getAlerts(ds: Datasource): Promise<{ alerts: OSAlert[]; totalAlerts: number }>;
-  acknowledgeAlerts(ds: Datasource, monitorId: string, alertIds: string[]): Promise<unknown>;
+  getAlerts(client: AlertingOSClient): Promise<{ alerts: OSAlert[]; totalAlerts: number }>;
+  acknowledgeAlerts(
+    client: AlertingOSClient,
+    monitorId: string,
+    alertIds: string[]
+  ): Promise<unknown>;
 
   // Destinations
-  getDestinations(ds: Datasource): Promise<OSDestination[]>;
-  createDestination(ds: Datasource, dest: Omit<OSDestination, 'id'>): Promise<OSDestination>;
-  deleteDestination(ds: Datasource, destId: string): Promise<boolean>;
+  getDestinations(client: AlertingOSClient): Promise<OSDestination[]>;
+  createDestination(
+    client: AlertingOSClient,
+    dest: Omit<OSDestination, 'id'>
+  ): Promise<OSDestination>;
+  deleteDestination(client: AlertingOSClient, destId: string): Promise<boolean>;
 }
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "antlr4": "4.8.0",
     "antlr4ts": "^0.5.0-alpha.4",
     "isomorphic-dompurify": "~2.26.0",
+    "js-yaml": "^4.1.1",
     "json5": "^2.2.3",
     "mime": "^3.0.0",
     "performance-now": "^2.1.0",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
+    "@types/js-yaml": "^4.0.5",
     "@types/mime": "^3.0.1",
     "@types/react-plotly.js": "^2.6.3",
     "@types/react-test-renderer": "^18.0.0",

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -14,7 +14,7 @@ import {
   DatasourceWarning,
   UnifiedAlert,
   UnifiedRule,
-} from '../../../server/services/alerting';
+} from '../../../common/types/alerting';
 import { MonitorsTable } from './monitors_table';
 import { CreateMonitor, MonitorFormState } from './create_monitor';
 import { AlertsDashboard } from './alerts_dashboard';
@@ -246,8 +246,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
   const handleDeleteRules = async (ids: string[]) => {
     const failed: string[] = [];
     for (const id of ids) {
+      const rule = rules.find((r) => r.id === id);
+      if (!rule) {
+        failed.push(id);
+        addToast('Failed to delete monitor', 'danger', `Monitor ${id} not found in cache`);
+        continue;
+      }
       try {
-        await apiClient.deleteMonitor(id);
+        await apiClient.deleteMonitor(id, rule.datasourceId);
       } catch (e: unknown) {
         failed.push(id);
         addToast('Failed to delete monitor', 'danger', e instanceof Error ? e.message : String(e));
@@ -277,7 +283,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
       createdBy: 'current-user',
     };
     try {
-      await apiClient.createMonitor(clone);
+      await apiClient.createMonitor(clone, clone.datasourceId);
       addToast('Monitor cloned');
       setRules((prev) => [clone, ...prev]);
     } catch (e: unknown) {
@@ -286,8 +292,13 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
   };
 
   const handleImportMonitors = async (configs: Array<Record<string, unknown>>) => {
+    const dsId = selectedDsIds[0];
+    if (!dsId) {
+      addToast('Select a datasource before importing monitors', 'warning');
+      return;
+    }
     try {
-      await apiClient.importMonitors(configs);
+      await apiClient.importMonitors(configs, dsId);
       addToast('Monitors imported successfully');
       fetchRules(selectedDsIds, rulesPage, rulesPageSize);
     } catch (e: unknown) {
@@ -374,7 +385,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
 
       return {
         id: `new-${Date.now()}-${index}`,
-        datasourceId: formState.datasourceId || selectedDsIds[0] || 'ds-1',
+        datasourceId: formState.datasourceId || selectedDsIds[0],
         datasourceType: 'opensearch',
         name: formState.name,
         enabled: formState.enabled,
@@ -417,10 +428,21 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
     }
   };
 
+  const resolveDatasourceId = (formState: MonitorFormState): string | null => {
+    const dsId = formState.datasourceId || selectedDsIds[0];
+    if (!dsId) {
+      addToast('Select a datasource before creating a monitor', 'warning');
+      return null;
+    }
+    return dsId;
+  };
+
   const handleCreateMonitor = async (formState: MonitorFormState) => {
+    const dsId = resolveDatasourceId(formState);
+    if (!dsId) return;
     const newRule = formStateToRule(formState);
     try {
-      await apiClient.createMonitor(formState);
+      await apiClient.createMonitor(formState, dsId);
       addToast('Monitor created successfully');
       setRules((prev) => [newRule, ...prev]);
       setRulesTotal((prev) => prev + 1);
@@ -433,8 +455,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
   const handleBatchCreateMonitors = async (forms: MonitorFormState[]) => {
     const succeededRules: UnifiedRule[] = [];
     for (let i = 0; i < forms.length; i++) {
+      const dsId = resolveDatasourceId(forms[i]);
+      if (!dsId) continue;
       try {
-        await apiClient.createMonitor(forms[i]);
+        await apiClient.createMonitor(forms[i], dsId);
         succeededRules.push(formStateToRule(forms[i], i));
       } catch (e: unknown) {
         addToast('Failed to create monitor', 'danger', e instanceof Error ? e.message : String(e));
@@ -555,7 +579,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
       : 'medium') as 'critical' | 'high' | 'medium' | 'low' | 'info';
     const newRule: UnifiedRule = {
       id: `new-logs-${Date.now()}`,
-      datasourceId: selectedDsIds[0] || 'ds-1',
+      datasourceId: selectedDsIds[0],
       datasourceType: 'opensearch',
       name: logsForm.monitorName,
       enabled: true,
@@ -592,8 +616,13 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw field is empty for new monitors
       raw: {} as any,
     };
+    const dsId = selectedDsIds[0];
+    if (!dsId) {
+      addToast('Select a datasource before creating a monitor', 'warning');
+      return;
+    }
     try {
-      await apiClient.createMonitor(transformLogsFormToPayload(logsForm), selectedDsIds[0]);
+      await apiClient.createMonitor(transformLogsFormToPayload(logsForm), dsId);
       addToast('Logs monitor created successfully');
       setRules((prev) => [newRule, ...prev]);
       setRulesTotal((prev) => prev + 1);

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -13,8 +13,9 @@ import { useToast } from '../common/toast';
 import {
   Datasource,
   DatasourceWarning,
-  UnifiedAlert,
+  UnifiedAlertSummary,
   UnifiedRule,
+  UnifiedRuleSummary,
 } from '../../../common/types/alerting';
 import { MonitorsTable } from './monitors_table';
 import { CreateMonitor, MonitorFormState } from './create_monitor';
@@ -28,6 +29,10 @@ import { CreateMetricsMonitor, MetricsMonitorFormState } from './create_metrics_
 import { AlarmsApiClient, HttpClient } from './services/alarms_client';
 import { setNavBreadCrumbs } from '../../../common/utils/set_nav_bread_crumbs';
 import { observabilityID, observabilityTitle } from '../../../common/constants/shared';
+import {
+  transformLogsFormToPayload,
+  transformMetricsFormToPayload,
+} from '../../../common/services/alerting/form_transforms';
 
 // Re-export for components that import from this file
 export { AlarmsApiClient, HttpClient };
@@ -61,13 +66,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
   const [error, setError] = useState<string | null>(null);
   const [warnings, setWarnings] = useState<Array<{ datasourceName: string; error: string }>>([]);
 
-  // Paginated data
-  const [alerts, setAlerts] = useState<UnifiedAlert[]>([]);
+  // Paginated data — list endpoints return summary shapes.
+  // Detail flyouts re-fetch the full UnifiedAlert / UnifiedRule on demand.
+  const [alerts, setAlerts] = useState<UnifiedAlertSummary[]>([]);
   const [alertsTotal, setAlertsTotal] = useState(0);
   const [alertsPage, setAlertsPage] = useState(1);
   const [alertsPageSize] = useState(DEFAULT_PAGE_SIZE);
 
-  const [rules, setRules] = useState<UnifiedRule[]>([]);
+  const [rules, setRules] = useState<UnifiedRuleSummary[]>([]);
   const [rulesTotal, setRulesTotal] = useState(-1); // -1 = not yet loaded
   const [rulesPage, setRulesPage] = useState(1);
   const [rulesPageSize] = useState(DEFAULT_PAGE_SIZE);
@@ -77,7 +83,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
   const [createMonitorType, setCreateMonitorType] = useState<
     'logs' | 'prometheus' | 'metrics' | null
   >(null);
-  const [selectedAlert, setSelectedAlert] = useState<UnifiedAlert | null>(null);
+  const [selectedAlert, setSelectedAlert] = useState<UnifiedAlertSummary | null>(null);
   const { setToast: addToast } = useToast();
 
   const visibleRules = rules.filter((r) => !deletedRuleIds.has(r.id));
@@ -264,8 +270,8 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
     }
   };
 
-  const handleCloneRule = async (monitor: UnifiedRule) => {
-    const clone: UnifiedRule = {
+  const handleCloneRule = async (monitor: UnifiedRuleSummary) => {
+    const clone: UnifiedRuleSummary = {
       ...monitor,
       id: `clone-${Date.now()}`,
       name: `${monitor.name} (Copy)`,
@@ -311,7 +317,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
       }
       return {
         id: `new-${Date.now()}-${index}`,
-        datasourceId: formState.datasourceId || selectedDsIds[0] || 'ds-2',
+        datasourceId: formState.datasourceId || selectedDsIds[0],
         datasourceType: 'prometheus',
         name: formState.name,
         enabled: formState.enabled,
@@ -428,12 +434,16 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
     return dsId;
   };
 
+  // TODO(alert-manager): this path posts the raw form state instead of an
+  // OS Monitor / Prometheus rule payload. The logs/metrics create flows
+  // already transform via transformLogsFormToPayload/transformMetricsFormToPayload;
+  // generic CreateMonitor should too. Casting here preserves current behavior.
   const handleCreateMonitor = async (formState: MonitorFormState) => {
     const dsId = resolveDatasourceId(formState);
     if (!dsId) return;
     const newRule = formStateToRule(formState);
     try {
-      await apiClient.createMonitor(formState, dsId);
+      await apiClient.createMonitor((formState as unknown) as Record<string, unknown>, dsId);
       addToast('Monitor created successfully');
       setRules((prev) => [newRule, ...prev]);
       setRulesTotal((prev) => prev + 1);
@@ -449,7 +459,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
       const dsId = resolveDatasourceId(forms[i]);
       if (!dsId) continue;
       try {
-        await apiClient.createMonitor(forms[i], dsId);
+        await apiClient.createMonitor((forms[i] as unknown) as Record<string, unknown>, dsId);
         succeededRules.push(formStateToRule(forms[i], i));
       } catch (e: unknown) {
         addToast('Failed to create monitor', 'danger', e instanceof Error ? e.message : String(e));
@@ -462,104 +472,6 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
     }
     // Don't close flyout — AI wizard shows its own summary step and "Done" button
   };
-
-  // ---- Form-to-API transformation helpers ----
-
-  const mapUnit = (unit: string): string => {
-    const lower = unit.toLowerCase().replace(/\(s\)$/, '');
-    if (lower === 'minute') return 'MINUTES';
-    if (lower === 'hour') return 'HOURS';
-    if (lower === 'day') return 'DAYS';
-    return 'MINUTES';
-  };
-
-  const mapSeverity = (severity: string): '1' | '2' | '3' | '4' | '5' => {
-    const map: Record<string, '1' | '2' | '3' | '4' | '5'> = {
-      critical: '1',
-      high: '2',
-      medium: '3',
-      low: '4',
-      info: '5',
-    };
-    return map[severity] || '3';
-  };
-
-  const buildConditionScript = (trigger: {
-    conditionOperator: string;
-    conditionValue: number;
-  }): string => {
-    const opMap: Record<string, string> = {
-      is_greater_than: '>',
-      is_less_than: '<',
-      is_equal_to: '==',
-      is_greater_equal: '>=',
-      is_less_equal: '<=',
-      is_not_equal: '!=',
-    };
-    const op = opMap[trigger.conditionOperator] || '>';
-    return `ctx.results[0].hits.total.value ${op} ${trigger.conditionValue}`;
-  };
-
-  const parseQuery = (query: string): Record<string, unknown> => {
-    try {
-      return JSON.parse(query);
-    } catch {
-      return { query_string: { query } };
-    }
-  };
-
-  const transformLogsFormToPayload = (form: LogsMonitorFormState): Record<string, unknown> => ({
-    type: 'monitor',
-    name: form.monitorName,
-    enabled: true,
-    schedule: {
-      period: { interval: form.runEveryValue, unit: mapUnit(form.runEveryUnit) },
-    },
-    inputs: [
-      {
-        search: {
-          indices: [form.selectedDatasource],
-          query: { size: 0, query: parseQuery(form.query) },
-        },
-      },
-    ],
-    triggers: form.triggers.map((t) => ({
-      name: t.name,
-      severity: mapSeverity(t.severityLevel),
-      condition: {
-        script: { source: buildConditionScript(t), lang: 'painless' },
-      },
-      actions: t.actions.map((a) => ({
-        name: a.name,
-        destination_id: a.notificationChannel,
-        message_template: { source: a.message || '' },
-        subject_template: { source: a.subject || '' },
-        throttle_enabled: t.suppressEnabled,
-        throttle: t.suppressEnabled
-          ? { value: t.suppressExpiry, unit: mapUnit(t.suppressExpiryUnit) }
-          : undefined,
-      })),
-    })),
-  });
-
-  const transformMetricsFormToPayload = (
-    form: MetricsMonitorFormState
-  ): Record<string, unknown> => ({
-    name: form.monitorName,
-    rules: [
-      {
-        alert: form.monitorName,
-        expr: `${form.query} ${form.operator} ${form.thresholdValue}`,
-        for: form.forDuration,
-        labels: Object.fromEntries(
-          form.labels.filter((l) => l.key && l.value).map((l) => [l.key, l.value])
-        ),
-        annotations: Object.fromEntries(
-          form.annotations.filter((a) => a.key && a.value).map((a) => [a.key, a.value])
-        ),
-      },
-    ],
-  });
 
   const handleCreateLogsMonitor = async (logsForm: LogsMonitorFormState) => {
     const now = new Date().toISOString();
@@ -642,7 +554,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
     }
     const newRule: UnifiedRule = {
       id: `new-metrics-${Date.now()}`,
-      datasourceId: metricsForm.datasourceId || selectedDsIds[0] || 'ds-2',
+      datasourceId: metricsForm.datasourceId || selectedDsIds[0],
       datasourceType: 'prometheus',
       name: metricsForm.monitorName,
       enabled: true,

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -8,7 +8,8 @@
  * Prometheus datasources are decomposed into selectable workspaces.
  */
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiSpacer, EuiTab, EuiTabs, EuiCallOut, EuiGlobalToastList } from '@elastic/eui';
+import { EuiSpacer, EuiTab, EuiTabs, EuiCallOut } from '@elastic/eui';
+import { useToast } from '../common/toast';
 import {
   Datasource,
   DatasourceWarning,
@@ -77,17 +78,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
     'logs' | 'prometheus' | 'metrics' | null
   >(null);
   const [selectedAlert, setSelectedAlert] = useState<UnifiedAlert | null>(null);
-  const [toasts, setToasts] = useState<
-    Array<{ id: string; title: string; color: string; text?: string }>
-  >([]);
-
-  const addToast = (
-    title: string,
-    color: 'success' | 'danger' | 'warning' = 'success',
-    text?: string
-  ) => {
-    setToasts((prev) => [...prev, { id: String(Date.now()), title, color, text }]);
-  };
+  const { setToast: addToast } = useToast();
 
   const visibleRules = rules.filter((r) => !deletedRuleIds.has(r.id));
 
@@ -840,12 +831,6 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
           }}
         />
       )}
-      <EuiGlobalToastList
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- EuiGlobalToastList toast type mismatch
-        toasts={toasts as any}
-        dismissToast={(t: { id: string }) => setToasts((prev) => prev.filter((p) => p.id !== t.id))}
-        toastLifeTimeMs={4000}
-      />
     </div>
   );
 };

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -30,7 +30,7 @@ import {
   EuiToolTip,
   EuiLink,
 } from '@elastic/eui';
-import { UnifiedAlert, Datasource } from '../../../common/types/alerting';
+import { UnifiedAlert, UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
 import { AlarmsApiClient } from './services/alarms_client';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
 
@@ -47,7 +47,7 @@ const INTERNAL_LABEL_KEYS = new Set([
 ]);
 
 export interface AlertDetailFlyoutProps {
-  alert: UnifiedAlert;
+  alert: UnifiedAlertSummary;
   datasources: Datasource[];
   apiClient: AlarmsApiClient;
   onClose: () => void;
@@ -61,7 +61,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
   onClose,
   onAcknowledge,
 }) => {
-  const [detailData, setDetailData] = useState<typeof alert | null>(null);
+  const [detailData, setDetailData] = useState<UnifiedAlert | null>(null);
 
   // Fetch full detail (with raw data) from the API when flyout opens
   useEffect(() => {
@@ -334,7 +334,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
           paddingSize="m"
         >
           <EuiCodeBlock language="json" fontSize="s" paddingSize="m" isCopyable>
-            {JSON.stringify(alertData.raw ?? alert, null, 2)}
+            {JSON.stringify(detailData?.raw ?? alert, null, 2)}
           </EuiCodeBlock>
         </EuiAccordion>
 
@@ -460,7 +460,7 @@ function getAlertDuration(startTime: string): string {
   return `${days}d ${hours % 24}h`;
 }
 
-function getAlertAiAnalysis(alert: UnifiedAlert): string {
+function getAlertAiAnalysis(alert: UnifiedAlertSummary): string {
   const analyses: Record<string, string> = {
     HighCpuUsage:
       'This host (i-0abc123) has sustained CPU usage above 80% for the past 5 minutes, currently at 92.3%. The spike correlates with increased request traffic. Consider scaling horizontally or investigating the workload causing the spike. Historical data shows this host has been consistently hot for 2 days.',
@@ -496,7 +496,7 @@ interface SuggestedAction {
   url?: string;
 }
 
-function getSuggestedActions(alert: UnifiedAlert): SuggestedAction[] {
+function getSuggestedActions(alert: UnifiedAlertSummary): SuggestedAction[] {
   const actions: SuggestedAction[] = [];
 
   if (alert.state === 'active') {

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -30,7 +30,7 @@ import {
   EuiToolTip,
   EuiLink,
 } from '@elastic/eui';
-import { UnifiedAlert, Datasource } from '../../../server/services/alerting';
+import { UnifiedAlert, Datasource } from '../../../common/types/alerting';
 import { AlarmsApiClient } from './services/alarms_client';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
 

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -15,11 +15,12 @@
  *  - AlertsByGroup: generic label-based grouping mini-chart
  */
 import React, { useMemo } from 'react';
+import type { EChartsOption } from 'echarts';
 import { EuiText } from '@elastic/eui';
 import { EchartsRender } from './echarts_render';
 import { escapeHtml, countBy } from './shared_constants';
 import {
-  UnifiedAlert,
+  UnifiedAlertSummary,
   UnifiedAlertSeverity,
   UnifiedAlertState,
 } from '../../../common/types/alerting';
@@ -68,7 +69,7 @@ const STATE_ORDER: UnifiedAlertState[] = [
 // SeverityDonut
 // ============================================================================
 
-export const SeverityDonut: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) => {
+export const SeverityDonut: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ alerts }) => {
   const spec = useMemo(() => {
     const counts = countBy(alerts, (a) => a.severity);
     const total = alerts.length;
@@ -132,7 +133,7 @@ export const SeverityDonut: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) 
 // AlertTimeline — stacked bar chart by time buckets
 // ============================================================================
 
-export const AlertTimeline: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) => {
+export const AlertTimeline: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ alerts }) => {
   const spec = useMemo(() => {
     if (alerts.length === 0) return null;
 
@@ -202,7 +203,7 @@ export const AlertTimeline: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) 
         name: s.key,
         type: 'bar' as const,
         stack: 'severity',
-        data: buckets.map((b) => (b as Record<string, number>)[s.key]),
+        data: buckets.map((b) => ((b as unknown) as Record<string, number>)[s.key]),
         itemStyle: { color: s.color },
         barMaxWidth: 32,
       })),
@@ -223,7 +224,7 @@ export const AlertTimeline: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) 
 // StateBreakdown — horizontal stacked bar
 // ============================================================================
 
-export const StateBreakdown: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) => {
+export const StateBreakdown: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ alerts }) => {
   const spec = useMemo(() => {
     const counts = countBy(alerts, (a) => a.state);
     const presentStates = STATE_ORDER.filter((s) => (counts[s] || 0) > 0);
@@ -261,8 +262,8 @@ export const StateBreakdown: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts })
 // AlertsByDatasource — horizontal bar chart
 // ============================================================================
 
-export const AlertsByDatasource: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) => {
-  const spec = useMemo(() => {
+export const AlertsByDatasource: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ alerts }) => {
+  const spec = useMemo<{ option: EChartsOption; rowCount: number } | null>(() => {
     const groups = countBy(alerts, (a) => a.datasourceType || 'unknown');
     const sorted = Object.entries(groups)
       .sort((a, b) => b[1] - a[1])
@@ -274,13 +275,14 @@ export const AlertsByDatasource: React.FC<{ alerts: UnifiedAlert[] }> = ({ alert
       )
       .reverse();
     const values = [...sorted].map(([, count]) => count).reverse();
-    return {
+    const option: EChartsOption = {
       tooltip: {
         trigger: 'axis' as const,
         axisPointer: { type: 'shadow' as const },
-        formatter: (
-          params: { name: string; value: number } | Array<{ name: string; value: number }>
-        ) => {
+        formatter: (rawParams: unknown) => {
+          const params = rawParams as
+            | { name: string; value: number }
+            | Array<{ name: string; value: number }>;
           const p = Array.isArray(params) ? params[0] : params;
           return `<b>${escapeHtml(p.name)}</b>: ${p.value}`;
         },
@@ -315,6 +317,7 @@ export const AlertsByDatasource: React.FC<{ alerts: UnifiedAlert[] }> = ({ alert
         },
       ],
     };
+    return { option, rowCount: names.length };
   }, [alerts]);
 
   if (!spec)
@@ -324,16 +327,15 @@ export const AlertsByDatasource: React.FC<{ alerts: UnifiedAlert[] }> = ({ alert
       </EuiText>
     );
 
-  const barCount = spec.yAxis.data.length;
-  return <EchartsRender spec={spec} height={Math.max(80, barCount * 28 + 16)} />;
+  return <EchartsRender spec={spec.option} height={Math.max(80, spec.rowCount * 28 + 16)} />;
 };
 
 // ============================================================================
 // AlertsByMonitor — horizontal bar chart
 // ============================================================================
 
-export const AlertsByMonitor: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }) => {
-  const spec = useMemo(() => {
+export const AlertsByMonitor: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ alerts }) => {
+  const spec = useMemo<{ option: EChartsOption; rowCount: number } | null>(() => {
     const groups = countBy(alerts, (a) => {
       const dashIdx = a.name.indexOf(' \u2014 ');
       return dashIdx > 0 ? a.name.substring(0, dashIdx) : a.name;
@@ -344,13 +346,14 @@ export const AlertsByMonitor: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }
     if (sorted.length === 0) return null;
     const names = [...sorted].map(([name]) => name).reverse();
     const values = [...sorted].map(([, count]) => count).reverse();
-    return {
+    const option: EChartsOption = {
       tooltip: {
         trigger: 'axis' as const,
         axisPointer: { type: 'shadow' as const },
-        formatter: (
-          params: { name: string; value: number } | Array<{ name: string; value: number }>
-        ) => {
+        formatter: (rawParams: unknown) => {
+          const params = rawParams as
+            | { name: string; value: number }
+            | Array<{ name: string; value: number }>;
           const p = Array.isArray(params) ? params[0] : params;
           return `<b>${escapeHtml(p.name)}</b>: ${p.value}`;
         },
@@ -385,6 +388,7 @@ export const AlertsByMonitor: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }
         },
       ],
     };
+    return { option, rowCount: names.length };
   }, [alerts]);
 
   if (!spec)
@@ -394,15 +398,14 @@ export const AlertsByMonitor: React.FC<{ alerts: UnifiedAlert[] }> = ({ alerts }
       </EuiText>
     );
 
-  const barCount = spec.yAxis.data.length;
-  return <EchartsRender spec={spec} height={Math.max(80, barCount * 28 + 16)} />;
+  return <EchartsRender spec={spec.option} height={Math.max(80, spec.rowCount * 28 + 16)} />;
 };
 
 // ============================================================================
 // AlertsByGroup — generic label-based grouping
 // ============================================================================
 
-export const AlertsByGroup: React.FC<{ alerts: UnifiedAlert[]; groupKey: string }> = ({
+export const AlertsByGroup: React.FC<{ alerts: UnifiedAlertSummary[]; groupKey: string }> = ({
   alerts,
   groupKey,
 }) => {

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -22,7 +22,7 @@ import {
   UnifiedAlert,
   UnifiedAlertSeverity,
   UnifiedAlertState,
-} from '../../../server/services/alerting';
+} from '../../../common/types/alerting';
 
 // ============================================================================
 // Color maps

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -25,7 +25,7 @@ import {
   EuiButtonEmpty,
   EuiResizableContainer,
 } from '@elastic/eui';
-import { UnifiedAlert, Datasource } from '../../../server/services/alerting';
+import { UnifiedAlert, Datasource } from '../../../common/types/alerting';
 import { filterAlerts } from '../../../common/services/alerting/filter';
 import {
   SeverityDonut,

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -25,7 +25,7 @@ import {
   EuiButtonEmpty,
   EuiResizableContainer,
 } from '@elastic/eui';
-import { UnifiedAlert, Datasource } from '../../../common/types/alerting';
+import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
 import { filterAlerts } from '../../../common/services/alerting/filter';
 import {
   SeverityDonut,
@@ -117,8 +117,8 @@ const emptyAlertFilters = (): AlertFilterState => ({
 });
 
 function collectAlertUniqueValues(
-  alerts: UnifiedAlert[],
-  field: (a: UnifiedAlert) => string
+  alerts: UnifiedAlertSummary[],
+  field: (a: UnifiedAlertSummary) => string
 ): string[] {
   const set = new Set<string>();
   for (const a of alerts) {
@@ -128,7 +128,7 @@ function collectAlertUniqueValues(
   return Array.from(set).sort();
 }
 
-function collectAlertLabelKeys(alerts: UnifiedAlert[]): string[] {
+function collectAlertLabelKeys(alerts: UnifiedAlertSummary[]): string[] {
   const keys = new Set<string>();
   for (const a of alerts) {
     for (const k of Object.keys(a.labels)) keys.add(k);
@@ -136,7 +136,7 @@ function collectAlertLabelKeys(alerts: UnifiedAlert[]): string[] {
   return Array.from(keys).sort();
 }
 
-function collectAlertLabelValues(alerts: UnifiedAlert[], key: string): string[] {
+function collectAlertLabelValues(alerts: UnifiedAlertSummary[], key: string): string[] {
   const set = new Set<string>();
   for (const a of alerts) {
     const v = a.labels[key];
@@ -154,8 +154,8 @@ function collectAlertLabelValues(alerts: UnifiedAlert[], key: string): string[] 
 // ============================================================================
 
 interface AlertsTableProps {
-  items: UnifiedAlert[];
-  columns: Array<EuiBasicTableColumn<UnifiedAlert>>;
+  items: UnifiedAlertSummary[];
+  columns: Array<EuiBasicTableColumn<UnifiedAlertSummary>>;
   loading: boolean;
   message: React.ReactNode;
 }
@@ -176,10 +176,10 @@ const AlertsTable = React.memo(({ items, columns, loading, message }: AlertsTabl
 // ============================================================================
 
 export interface AlertsDashboardProps {
-  alerts: UnifiedAlert[];
+  alerts: UnifiedAlertSummary[];
   datasources: Datasource[];
   loading: boolean;
-  onViewDetail: (alert: UnifiedAlert) => void;
+  onViewDetail: (alert: UnifiedAlertSummary) => void;
   onAcknowledge: (alertId: string) => void;
   /** Currently selected datasource IDs */
   selectedDsIds: string[];
@@ -348,13 +348,13 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
 
   // Table columns — memoized so `AlertsTable`'s React.memo shallow-compare
   // doesn't invalidate on every parent re-render.
-  const columns = useMemo<Array<EuiBasicTableColumn<UnifiedAlert>>>(
+  const columns = useMemo<Array<EuiBasicTableColumn<UnifiedAlertSummary>>>(
     () => [
       {
         field: 'severity',
         name: 'Sev',
         width: '60px',
-        sortable: (a: UnifiedAlert) => SEVERITY_SORT_ORDER[a.severity] ?? 5,
+        sortable: (a: UnifiedAlertSummary) => SEVERITY_SORT_ORDER[a.severity] ?? 5,
         render: (s: string) => (
           <EuiToolTip content={s}>
             <span
@@ -374,7 +374,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: 'Alert',
         sortable: true,
         truncateText: true,
-        render: (name: string, alert: UnifiedAlert) => (
+        render: (name: string, alert: UnifiedAlertSummary) => (
           <EuiButtonEmpty
             size="xs"
             flush="left"
@@ -438,7 +438,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
       {
         name: 'Actions',
         width: '150px',
-        render: (alert: UnifiedAlert) => (
+        render: (alert: UnifiedAlertSummary) => (
           <EuiFlexGroup gutterSize="xs" responsive={false} wrap={false} alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiToolTip content="View details">

--- a/public/components/alerting/create_monitor.tsx
+++ b/public/components/alerting/create_monitor.tsx
@@ -36,7 +36,7 @@ import {
 } from '@elastic/eui';
 import { PromQLEditor, validatePromQL } from './promql_editor';
 import { MetricBrowser } from './metric_browser';
-import { Datasource, UnifiedAlertSeverity } from '../../../server/services/alerting';
+import { Datasource, UnifiedAlertSeverity } from '../../../common/types/alerting';
 import {
   validateMonitorForm,
   MonitorFormState as ValidatorFormState,

--- a/public/components/alerting/home.tsx
+++ b/public/components/alerting/home.tsx
@@ -5,16 +5,15 @@
 
 import React, { useMemo } from 'react';
 import { HashRouter, Route } from 'react-router-dom';
-import { CoreStart } from '../../../../../src/core/public';
+import { coreRefs } from '../../framework/core_refs';
 import { AlarmsPage } from './alarms_page';
 import { AlarmsApiClient } from './services/alarms_client';
 
-interface AlertingHomeProps {
-  CoreStartProp: CoreStart;
-}
+export const AlertingHome = () => {
+  const http = coreRefs.http;
+  const apiClient = useMemo(() => (http ? new AlarmsApiClient(http) : null), [http]);
 
-export const AlertingHome = ({ CoreStartProp }: AlertingHomeProps) => {
-  const apiClient = useMemo(() => new AlarmsApiClient(CoreStartProp.http), [CoreStartProp.http]);
+  if (!apiClient) return null;
 
   return (
     <HashRouter>

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -28,7 +28,6 @@ import {
   EuiBasicTable,
   EuiAccordion,
   EuiToolTip,
-  EuiConfirmModal,
   EuiCodeBlock,
   EuiIcon,
   EuiLoadingContent,
@@ -42,6 +41,7 @@ import {
   OSMonitorInput,
 } from '../../../common/types/alerting';
 import { AlarmsApiClient } from './services/alarms_client';
+import { DeleteModal } from '../common/helpers/delete_modal';
 
 import { SEVERITY_COLORS, STATE_COLORS, STATUS_COLORS, HEALTH_COLORS } from './shared_constants';
 
@@ -693,23 +693,16 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
 
       {/* Delete confirmation */}
       {showDeleteConfirm && (
-        <EuiConfirmModal
+        <DeleteModal
           title={`Delete "${monitor.name}"?`}
+          message="This will remove the monitor from the current view."
           onCancel={() => setShowDeleteConfirm(false)}
           onConfirm={() => {
             onDelete(monitor.id);
             setShowDeleteConfirm(false);
             onClose();
           }}
-          cancelButtonText="Cancel"
-          confirmButtonText="Delete"
-          buttonColor="danger"
-        >
-          <p>
-            This will remove the monitor from the current view. This action cannot be undone within
-            this session.
-          </p>
-        </EuiConfirmModal>
+        />
       )}
     </>
   );

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -40,7 +40,7 @@ import {
   UnifiedAlertSeverity,
   OSMonitor,
   OSMonitorInput,
-} from '../../../server/services/alerting';
+} from '../../../common/types/alerting';
 import { AlarmsApiClient } from './services/alarms_client';
 
 import { SEVERITY_COLORS, STATE_COLORS, STATUS_COLORS, HEALTH_COLORS } from './shared_constants';

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -26,6 +26,7 @@ import {
   EuiPanel,
   EuiDescriptionList,
   EuiBasicTable,
+  EuiBasicTableColumn,
   EuiAccordion,
   EuiToolTip,
   EuiCodeBlock,
@@ -35,10 +36,13 @@ import {
 } from '@elastic/eui';
 import { EchartsRender } from './echarts_render';
 import {
-  UnifiedRule,
-  UnifiedAlertSeverity,
+  AlertHistoryEntry,
+  NotificationRouting,
   OSMonitor,
   OSMonitorInput,
+  UnifiedAlertSeverity,
+  UnifiedRule,
+  UnifiedRuleSummary,
 } from '../../../common/types/alerting';
 import { AlarmsApiClient } from './services/alarms_client';
 import { DeleteModal } from '../common/helpers/delete_modal';
@@ -176,11 +180,11 @@ const ConditionPreviewGraph: React.FC<{
 // ============================================================================
 
 export interface MonitorDetailFlyoutProps {
-  monitor: UnifiedRule;
+  monitor: UnifiedRuleSummary;
   apiClient: AlarmsApiClient;
   onClose: () => void;
   onDelete: (id: string) => void;
-  onClone: (monitor: UnifiedRule) => void;
+  onClone: (monitor: UnifiedRuleSummary) => void;
 }
 
 // ============================================================================
@@ -220,16 +224,17 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
     };
   }, [monitor.datasourceId, monitor.id, apiClient]);
 
-  // Use detail data when available, fall back to summary props
-  const full = detail || monitor;
-  const alertHistory = full.alertHistory ?? [];
-  const conditionPreviewData = full.conditionPreviewData ?? [];
-  const notificationRouting = full.notificationRouting ?? [];
-  const suppressionRules = full.suppressionRules ?? [];
-  const description = full.description ?? '';
-  const aiSummary = full.aiSummary ?? '';
-  const evaluationInterval = full.evaluationInterval ?? '—';
-  const pendingPeriod = full.pendingPeriod ?? '—';
+  // Use detail data when available, fall back to summary props.
+  // `detail` has the full shape; `monitor` is only a summary, so
+  // detail-only fields are empty until the fetch resolves.
+  const alertHistory = detail?.alertHistory ?? [];
+  const conditionPreviewData = detail?.conditionPreviewData ?? [];
+  const notificationRouting = detail?.notificationRouting ?? [];
+  const suppressionRules = detail?.suppressionRules ?? [];
+  const description = detail?.description ?? '';
+  const aiSummary = detail?.aiSummary ?? '';
+  const evaluationInterval = detail?.evaluationInterval ?? monitor.evaluationInterval ?? '—';
+  const pendingPeriod = detail?.pendingPeriod ?? monitor.pendingPeriod ?? '—';
 
   const isJson = (s: string) => {
     try {
@@ -246,12 +251,12 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
 
   // Detect monitor kind from raw data for type-specific rendering
   const monitorKind = monitor.labels?.monitor_kind as string | undefined;
-  const rawMonitor = (full as UnifiedRule).raw as OSMonitor | undefined;
+  const rawMonitor = detail?.raw as OSMonitor | undefined;
   const rawInput: OSMonitorInput | undefined =
     rawMonitor && 'inputs' in rawMonitor ? rawMonitor.inputs?.[0] : undefined;
 
   // Alert history columns
-  const historyColumns = [
+  const historyColumns: Array<EuiBasicTableColumn<AlertHistoryEntry>> = [
     {
       field: 'timestamp',
       name: 'Time',
@@ -268,7 +273,7 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   ];
 
   // Notification routing columns
-  const routingColumns = [
+  const routingColumns: Array<EuiBasicTableColumn<NotificationRouting>> = [
     { field: 'channel', name: 'Channel', width: '100px' },
     { field: 'destination', name: 'Destination' },
     {
@@ -492,11 +497,11 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                   listItems={[
                     { title: 'Evaluation Interval', description: evaluationInterval },
                     { title: 'Pending Period', description: pendingPeriod },
-                    ...(monitor.firingPeriod
-                      ? [{ title: 'Firing Period', description: monitor.firingPeriod }]
+                    ...(detail?.firingPeriod
+                      ? [{ title: 'Firing Period', description: detail.firingPeriod }]
                       : []),
-                    ...(monitor.lookbackPeriod
-                      ? [{ title: 'Lookback Period', description: monitor.lookbackPeriod }]
+                    ...(detail?.lookbackPeriod
+                      ? [{ title: 'Lookback Period', description: detail.lookbackPeriod }]
                       : []),
                     ...(monitor.threshold
                       ? [

--- a/public/components/alerting/monitor_form_components.tsx
+++ b/public/components/alerting/monitor_form_components.tsx
@@ -27,7 +27,7 @@ import {
   EuiBadge,
   EuiToolTip,
 } from '@elastic/eui';
-import { Datasource } from '../../../server/services/alerting';
+import { Datasource } from '../../../common/types/alerting';
 
 // ============================================================================
 // Types

--- a/public/components/alerting/monitors_table.tsx
+++ b/public/components/alerting/monitors_table.tsx
@@ -30,7 +30,7 @@ import {
   EuiListGroupItem,
 } from '@elastic/eui';
 import {
-  UnifiedRule,
+  UnifiedRuleSummary,
   UnifiedAlertSeverity,
   MonitorType,
   MonitorStatus,
@@ -96,13 +96,13 @@ const emptyFilters = (): FilterState => ({
 });
 
 interface MonitorsTableProps {
-  rules: UnifiedRule[];
+  rules: UnifiedRuleSummary[];
   datasources: Datasource[];
   loading: boolean;
   apiClient: import('./services/alarms_client').AlarmsApiClient;
   onDelete: (ids: string[]) => void;
-  onClone?: (monitor: UnifiedRule) => void;
-  onImport?: (configs: unknown[]) => void;
+  onClone?: (monitor: UnifiedRuleSummary) => void;
+  onImport?: (configs: Array<Record<string, unknown>>) => void;
   onCreateMonitor?: (type: 'logs' | 'prometheus' | 'metrics' | 'slo') => void;
   /** Currently selected datasource IDs */
   selectedDsIds: string[];
@@ -114,7 +114,7 @@ interface MonitorsTableProps {
 // Suggestion Engine
 // ============================================================================
 
-function buildSuggestions(rules: UnifiedRule[]): string[] {
+function buildSuggestions(rules: UnifiedRuleSummary[]): string[] {
   const set = new Set<string>();
   for (const r of rules) {
     set.add(r.name);
@@ -129,7 +129,7 @@ function buildSuggestions(rules: UnifiedRule[]): string[] {
   return Array.from(set).sort();
 }
 
-function matchesSearch(rule: UnifiedRule, query: string): boolean {
+function matchesSearch(rule: UnifiedRuleSummary, query: string): boolean {
   if (!query) return true;
   const q = query.toLowerCase();
   const terms = q.split(/\s+/).filter(Boolean);
@@ -153,7 +153,7 @@ function matchesSearch(rule: UnifiedRule, query: string): boolean {
   });
 }
 
-function matchesFilters(rule: UnifiedRule, filters: FilterState): boolean {
+function matchesFilters(rule: UnifiedRuleSummary, filters: FilterState): boolean {
   if (filters.status.length > 0 && !filters.status.includes(rule.status)) return false;
   if (filters.severity.length > 0 && !filters.severity.includes(rule.severity)) return false;
   if (filters.monitorType.length > 0 && !filters.monitorType.includes(rule.monitorType))
@@ -179,7 +179,7 @@ function matchesFilters(rule: UnifiedRule, filters: FilterState): boolean {
 // All unique label keys from rules
 // ============================================================================
 
-function collectLabelKeys(rules: UnifiedRule[]): string[] {
+function collectLabelKeys(rules: UnifiedRuleSummary[]): string[] {
   const keys = new Set<string>();
   for (const r of rules) {
     for (const k of Object.keys(r.labels)) keys.add(k);
@@ -188,8 +188,8 @@ function collectLabelKeys(rules: UnifiedRule[]): string[] {
 }
 
 function collectUniqueValues(
-  rules: UnifiedRule[],
-  field: (r: UnifiedRule) => string | string[]
+  rules: UnifiedRuleSummary[],
+  field: (r: UnifiedRuleSummary) => string | string[]
 ): string[] {
   const set = new Set<string>();
   for (const r of rules) {
@@ -200,7 +200,7 @@ function collectUniqueValues(
   return Array.from(set).sort();
 }
 
-function collectLabelValues(rules: UnifiedRule[], key: string): string[] {
+function collectLabelValues(rules: UnifiedRuleSummary[], key: string): string[] {
   const set = new Set<string>();
   for (const r of rules) {
     const v = r.labels[key];
@@ -386,11 +386,11 @@ function useResizableColumns(
 // ============================================================================
 
 interface MonitorsEuiTableProps {
-  items: UnifiedRule[];
+  items: UnifiedRuleSummary[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- EuiInMemoryTable column type is complex
   columns: any[];
   loading: boolean;
-  rowProps: (item: UnifiedRule) => React.HTMLAttributes<HTMLTableRowElement>;
+  rowProps: (item: UnifiedRuleSummary) => React.HTMLAttributes<HTMLTableRowElement>;
 }
 
 const MonitorsEuiTable = React.memo(
@@ -433,7 +433,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [activeSuggestion, setActiveSuggestion] = useState(-1);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({ ...DEFAULT_WIDTHS });
-  const [selectedMonitor, setSelectedMonitor] = useState<UnifiedRule | null>(null);
+  const [selectedMonitor, setSelectedMonitor] = useState<UnifiedRuleSummary | null>(null);
   const [showCreatePopover, setShowCreatePopover] = useState(false);
   const [showSaveSearchInput, setShowSaveSearchInput] = useState(false);
   const [saveSearchName, setSaveSearchName] = useState('');
@@ -441,7 +441,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   const tableWrapperRef = useRef<HTMLDivElement>(null);
 
   const rowProps = useCallback(
-    (item: UnifiedRule) => ({
+    (item: UnifiedRuleSummary) => ({
       style: selectedIds.has(item.id) ? { backgroundColor: '#F0F5FF' } : undefined,
     }),
     [selectedIds]
@@ -560,7 +560,8 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
         try {
           const data = JSON.parse(ev.target?.result as string);
           const configs = Array.isArray(data) ? data : data.monitors;
-          if (onImport && Array.isArray(configs)) onImport(configs);
+          if (onImport && Array.isArray(configs))
+            onImport(configs as Array<Record<string, unknown>>);
         } catch (_err) {
           alert('Invalid JSON file');
         }
@@ -594,7 +595,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
           />
         ),
         width: '32px',
-        render: (_: unknown, item: UnifiedRule) => (
+        render: (_: unknown, item: UnifiedRuleSummary) => (
           <input
             type="checkbox"
             checked={selectedIds.has(item.id)}
@@ -613,7 +614,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
           sortable: true,
           truncateText: true,
           width: w('name'),
-          render: (name: string, item: UnifiedRule) => (
+          render: (name: string, item: UnifiedRuleSummary) => (
             <span
               role="button"
               tabIndex={0}
@@ -701,7 +702,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
         cols.push({
           field: 'datasourceId',
           name: 'Datasource',
-          sortable: (r: UnifiedRule) =>
+          sortable: (r: UnifiedRuleSummary) =>
             (dsNameMap.get(r.datasourceId) || r.datasourceId).toLowerCase(),
           width: w('datasource'),
           render: (id: string) => dsNameMap.get(id) || id,

--- a/public/components/alerting/monitors_table.tsx
+++ b/public/components/alerting/monitors_table.tsx
@@ -37,7 +37,7 @@ import {
   MonitorStatus,
   MonitorHealthStatus,
   Datasource,
-} from '../../../server/services/alerting';
+} from '../../../common/types/alerting';
 import { serializeMonitors } from '../../../common/services/alerting/serializer';
 import { MonitorDetailFlyout } from './monitor_detail_flyout';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
@@ -99,7 +99,7 @@ interface MonitorsTableProps {
   rules: UnifiedRule[];
   datasources: Datasource[];
   loading: boolean;
-  apiClient: import('../services/alarms_client').AlarmsApiClient;
+  apiClient: import('./services/alarms_client').AlarmsApiClient;
   onDelete: (ids: string[]) => void;
   onClone?: (monitor: UnifiedRule) => void;
   onImport?: (configs: unknown[]) => void;

--- a/public/components/alerting/monitors_table.tsx
+++ b/public/components/alerting/monitors_table.tsx
@@ -22,7 +22,6 @@ import {
   EuiPopover,
   EuiCheckboxGroup,
   EuiEmptyPrompt,
-  EuiConfirmModal,
   EuiText,
   EuiPanel,
   EuiButtonIcon,
@@ -41,6 +40,7 @@ import {
 import { serializeMonitors } from '../../../common/services/alerting/serializer';
 import { MonitorDetailFlyout } from './monitor_detail_flyout';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
+import { DeleteModal } from '../common/helpers/delete_modal';
 import { SEVERITY_COLORS, STATUS_COLORS, HEALTH_COLORS, TYPE_LABELS } from './shared_constants';
 
 // ============================================================================
@@ -1426,19 +1426,14 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
 
               {/* Delete confirmation modal */}
               {showDeleteConfirm && (
-                <EuiConfirmModal
+                <DeleteModal
                   title={`Delete ${selectedIds.size} monitor${selectedIds.size > 1 ? 's' : ''}?`}
+                  message={`This will remove the selected monitor${
+                    selectedIds.size > 1 ? 's' : ''
+                  } from the current view.`}
                   onCancel={() => setShowDeleteConfirm(false)}
                   onConfirm={handleBulkDelete}
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Delete"
-                  buttonColor="danger"
-                >
-                  <p>
-                    This will remove the selected monitor{selectedIds.size > 1 ? 's' : ''} from the
-                    current view. This action cannot be undone within this session.
-                  </p>
-                </EuiConfirmModal>
+                />
               )}
 
               {/* Monitor detail flyout */}

--- a/public/components/alerting/notification_routing_panel.tsx
+++ b/public/components/alerting/notification_routing_panel.tsx
@@ -12,6 +12,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
   EuiBasicTable,
+  EuiBasicTableColumn,
   EuiBadge,
   EuiButtonIcon,
   EuiCallOut,
@@ -161,7 +162,9 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
     setError(null);
     try {
       const res = await apiClient.getAlertmanagerConfig();
-      setConfig(res);
+      // The API client types route/inhibitRules as `unknown` because it's
+      // handed back raw from Alertmanager; narrow to our local shape here.
+      setConfig((res as unknown) as AlertmanagerConfig);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to fetch Alertmanager config');
     }
@@ -290,7 +293,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
   // Receivers table
   // -----------------------------------------------------------------------
 
-  const receiverColumns = [
+  const receiverColumns: Array<EuiBasicTableColumn<ReceiverInfo>> = [
     { field: 'name', name: 'Receiver', sortable: true },
     {
       field: 'integrations',

--- a/public/components/alerting/services/alarms_client.ts
+++ b/public/components/alerting/services/alarms_client.ts
@@ -12,8 +12,8 @@
  *  - Request deduplication for concurrent calls
  *  - Full CRUD: monitors, alert actions
  */
-import { Datasource } from '../../../../server/services/alerting';
 import type {
+  Datasource,
   DatasourceWarning,
   PrometheusMetricMetadata,
   UnifiedAlertSummary,
@@ -21,7 +21,7 @@ import type {
   UnifiedAlert,
   UnifiedRule,
   OSMonitor,
-} from '../../../../common/types/alerting/types';
+} from '../../../../common/types/alerting';
 
 // ---------------------------------------------------------------------------
 // HttpClient interface — implemented by OSD's http service adapter or fetch()
@@ -254,32 +254,32 @@ export class AlarmsApiClient {
 
   async createMonitor(
     data: Partial<OSMonitor> | Record<string, unknown>,
-    dsId = 'ds-1'
+    dsId: string
   ): Promise<MonitorResponse> {
     return this.httpPost<MonitorResponse>(this.paths.monitors(dsId), data);
   }
   async updateMonitor(
     id: string,
     data: Partial<OSMonitor> | Record<string, unknown>,
-    dsId = 'ds-1'
+    dsId: string
   ): Promise<MonitorResponse> {
     return this.httpPut<MonitorResponse>(
       `${this.paths.monitors(dsId)}/${encodeURIComponent(id)}`,
       data
     );
   }
-  async deleteMonitor(id: string, dsId = 'ds-1'): Promise<MonitorDeleteResponse> {
+  async deleteMonitor(id: string, dsId: string): Promise<MonitorDeleteResponse> {
     return this.httpDelete<MonitorDeleteResponse>(
       `${this.paths.monitors(dsId)}/${encodeURIComponent(id)}`
     );
   }
   async importMonitors(
     json: Array<Record<string, unknown>>,
-    dsId = 'ds-1'
+    dsId: string
   ): Promise<MonitorImportResponse> {
     return this.httpPost<MonitorImportResponse>(`${this.paths.monitors(dsId)}/import`, json);
   }
-  async exportMonitors(dsId = 'ds-1'): Promise<MonitorExportResponse> {
+  async exportMonitors(dsId: string): Promise<MonitorExportResponse> {
     return this.httpGet<MonitorExportResponse>(`${this.paths.monitors(dsId)}/export`);
   }
 

--- a/server/routes/alerting/alertmanager_handlers.ts
+++ b/server/routes/alerting/alertmanager_handlers.ts
@@ -8,7 +8,11 @@
  * Each handler takes a PrometheusBackend and returns { status, body }.
  */
 import yaml from 'js-yaml';
-import { AlertingOSClient, AlertmanagerSilence, PrometheusBackend } from '../../services/alerting';
+import type {
+  AlertingOSClient,
+  AlertmanagerSilence,
+  PrometheusBackend,
+} from '../../../common/types/alerting';
 import { toHandlerResult } from './route_utils';
 import type { HandlerResult } from './route_utils';
 

--- a/server/routes/alerting/handlers.ts
+++ b/server/routes/alerting/handlers.ts
@@ -7,13 +7,13 @@
  * Route handlers — pure functions that work with any HTTP framework.
  * Exposes backend-native API shapes + unified views.
  */
-import {
+import type {
   AlertingOSClient,
   DatasourceService,
   Datasource,
-  MultiBackendAlertService,
   OSMonitor,
-} from '../../services/alerting';
+} from '../../../common/types/alerting';
+import { MultiBackendAlertService } from '../../services/alerting';
 import { toHandlerResult } from './route_utils';
 import type { HandlerResult } from './route_utils';
 

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -11,10 +11,11 @@ import { IRouter, RequestHandlerContext, SavedObject } from '../../../../../src/
 import type {
   AlertingOSClient,
   Datasource,
-  DatasourceService,
   Logger,
+  OSMonitor,
 } from '../../../common/types/alerting';
 import { MultiBackendAlertService } from '../../services/alerting';
+import type { InMemoryDatasourceService } from '../../services/alerting/datasource_service';
 
 /**
  * Shape of the OSD request-handler context we rely on. `dataSource` is
@@ -38,6 +39,7 @@ interface DataConnectionSOAttributes {
   connectionId?: string;
   type?: string;
 }
+
 import {
   handleListDatasources,
   handleGetDatasource,
@@ -68,9 +70,25 @@ import {
 import type { PrometheusMetadataService } from '../../services/alerting/prometheus_metadata_service';
 import { handleGetAlertmanagerConfig } from './alertmanager_handlers';
 
+/**
+ * Adapt handler-result body ({ error: '...' } or arbitrary data) to OSD's
+ * ResponseError shape ({ message, attributes }). `error` → `message`, and the
+ * remaining fields become `attributes`.
+ */
+function toErrorBody(
+  body: Record<string, unknown>
+): { message: string; attributes?: Record<string, unknown> } {
+  const { error, message, ...rest } = body as { error?: unknown; message?: unknown };
+  const text =
+    typeof error === 'string' ? error : typeof message === 'string' ? message : 'An error occurred';
+  return Object.keys(rest).length > 0
+    ? { message: text, attributes: rest as Record<string, unknown> }
+    : { message: text };
+}
+
 export function registerAlertingRoutes(
   router: IRouter,
-  datasourceService: DatasourceService,
+  datasourceService: InMemoryDatasourceService,
   alertService: MultiBackendAlertService,
   logger?: Logger,
   metadataService?: PrometheusMetadataService
@@ -199,7 +217,7 @@ export function registerAlertingRoutes(
       const result = await handleGetDatasource(datasourceService, req.params.id);
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 
@@ -244,7 +262,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 
@@ -257,7 +275,7 @@ export function registerAlertingRoutes(
       const result = await handleDeleteDatasource(datasourceService, req.params.id);
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 
@@ -341,7 +359,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.badRequest({ body: result.body });
+        : res.badRequest({ body: toErrorBody(result.body) });
     }
   );
 
@@ -359,7 +377,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 
@@ -446,7 +464,8 @@ export function registerAlertingRoutes(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
         req.params.dsId,
-        req.body
+        // OSD schema validates loosely; narrow to the typed domain shape
+        (req.body as unknown) as Omit<OSMonitor, 'id'>
       );
       return res.ok({ body: result.body });
     }
@@ -466,11 +485,12 @@ export function registerAlertingRoutes(
         await getAlertingClient(ctx, req.params.dsId),
         req.params.dsId,
         req.params.monitorId,
-        req.body
+        // OSD schema validates loosely; narrow to the typed domain shape
+        (req.body as unknown) as Partial<OSMonitor>
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 
@@ -490,9 +510,9 @@ export function registerAlertingRoutes(
         );
         return result.status === 200
           ? res.ok({ body: result.body })
-          : res.notFound({ body: result.body });
+          : res.notFound({ body: toErrorBody(result.body) });
       } catch (_e) {
-        return res.badRequest({ body: { error: `Invalid datasource: ${req.params.dsId}` } });
+        return res.badRequest({ body: { message: `Invalid datasource: ${req.params.dsId}` } });
       }
     }
   );
@@ -510,7 +530,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.badRequest({ body: result.body });
+        : res.badRequest({ body: toErrorBody(result.body) });
     }
   );
 
@@ -548,7 +568,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.badRequest({ body: result.body });
+        : res.badRequest({ body: toErrorBody(result.body) });
     }
   );
 
@@ -565,7 +585,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.badRequest({ body: result.body });
+        : res.badRequest({ body: toErrorBody(result.body) });
     }
   );
 
@@ -586,7 +606,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 
@@ -606,7 +626,7 @@ export function registerAlertingRoutes(
       );
       return result.status === 200
         ? res.ok({ body: result.body })
-        : res.notFound({ body: result.body });
+        : res.notFound({ body: toErrorBody(result.body) });
     }
   );
 

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -8,13 +8,13 @@
  */
 import { schema } from '@osd/config-schema';
 import { IRouter, RequestHandlerContext, SavedObject } from '../../../../../src/core/server';
-import {
+import type {
   AlertingOSClient,
   Datasource,
   DatasourceService,
-  MultiBackendAlertService,
   Logger,
-} from '../../services/alerting';
+} from '../../../common/types/alerting';
+import { MultiBackendAlertService } from '../../services/alerting';
 
 /**
  * Shape of the OSD request-handler context we rely on. `dataSource` is

--- a/server/services/alerting/datasource_service.ts
+++ b/server/services/alerting/datasource_service.ts
@@ -7,6 +7,7 @@
  * Datasource service — manages alert datasource configurations
  */
 import {
+  AlertingOSClient,
   Datasource,
   DatasourceService,
   PrometheusBackend,
@@ -55,7 +56,10 @@ export class InMemoryDatasourceService implements DatasourceService {
     return existed;
   }
 
-  async testConnection(client: any, id: string): Promise<{ success: boolean; message: string }> {
+  async testConnection(
+    client: AlertingOSClient,
+    id: string
+  ): Promise<{ success: boolean; message: string }> {
     const datasource = this.datasources.get(id);
     if (!datasource) {
       return { success: false, message: 'Datasource not found' };
@@ -90,7 +94,7 @@ export class InMemoryDatasourceService implements DatasourceService {
     }
   }
 
-  async listWorkspaces(client: any, dsId: string): Promise<Datasource[]> {
+  async listWorkspaces(client: AlertingOSClient, dsId: string): Promise<Datasource[]> {
     const ds = this.datasources.get(dsId);
     if (!ds || ds.type !== 'prometheus' || !this.promBackend) return [];
 

--- a/server/services/alerting/index.ts
+++ b/server/services/alerting/index.ts
@@ -4,47 +4,17 @@
  */
 
 /**
- * Alerting services — Phase 1 exports (Alerts, Rules, Routing)
+ * Alerting services — server-side barrel (routes wiring entry point).
+ * Runtime classes and error helpers only. Types live in `common/types/alerting`;
+ * framework-agnostic helpers live in `common/services/alerting`.
  */
 export { PLUGIN_ID, PLUGIN_NAME } from './constants';
 
-export * from '../../../common/types/alerting/types';
 export { InMemoryDatasourceService } from './datasource_service';
 export { MultiBackendAlertService } from './alert_service';
 export { HttpOpenSearchBackend } from './opensearch_backend';
 export { DirectQueryPrometheusBackend } from './directquery_prometheus_backend';
 export type { DirectQueryConfig } from './directquery_prometheus_backend';
-export {
-  parseDuration,
-  formatDuration,
-  validateMonitorForm,
-} from '../../../common/services/alerting/validators';
-export type {
-  MonitorFormState,
-  ValidationResult,
-  ThresholdCondition,
-  LabelEntry,
-  AnnotationEntry,
-} from '../../../common/services/alerting/validators';
-export { validatePromQL, prettifyPromQL } from '../../../common/services/alerting/promql_validator';
-export type {
-  PromQLError,
-  PromQLValidationResult,
-} from '../../../common/services/alerting/promql_validator';
-export {
-  serializeMonitor,
-  serializeMonitors,
-  deserializeMonitor,
-} from '../../../common/services/alerting/serializer';
-export type { MonitorConfig } from '../../../common/services/alerting/serializer';
-export {
-  matchesSearch,
-  matchesFilters,
-  sortRules,
-  filterAlerts,
-  emptyFilters,
-} from '../../../common/services/alerting/filter';
-export type { FilterState } from '../../../common/services/alerting/filter';
 
 export type { AlertManagerError, NotFoundError, ValidationError, InternalError } from './errors';
 export {

--- a/server/services/alerting/mock_backend.ts
+++ b/server/services/alerting/mock_backend.ts
@@ -5,9 +5,13 @@
 
 /**
  * Mock backends — simulate real OpenSearch Alerting and Prometheus API responses.
+ *
+ * The mock is datasource-agnostic: it maintains a single in-memory dataset and
+ * ignores the `client` argument. Tests that need to simulate multiple
+ * datasources should run against the real backend.
  */
 import {
-  Datasource,
+  AlertingOSClient,
   Logger,
   OpenSearchBackend,
   OSMonitor,
@@ -18,14 +22,19 @@ import {
 let idCounter = 100;
 const nextId = () => `mock-${++idCounter}`;
 
+// Key used for the single-bucket in-memory storage. The mock used to partition
+// by datasource id; now it's flat, but we keep a constant key so the existing
+// seeding path (`seed(dsId)`) keeps working unchanged.
+const MOCK_KEY = '__mock__';
+
 // ============================================================================
 // Mock OpenSearch Alerting Backend
 // ============================================================================
 
 export class MockOpenSearchBackend implements OpenSearchBackend {
   readonly type = 'opensearch' as const;
-  private monitors: Map<string, Map<string, OSMonitor>> = new Map(); // dsId -> monitorId -> monitor
-  private alerts: Map<string, OSAlert[]> = new Map(); // dsId -> alerts
+  private monitors: Map<string, Map<string, OSMonitor>> = new Map(); // bucket -> monitorId -> monitor
+  private alerts: Map<string, OSAlert[]> = new Map();
   private destinations: Map<string, Map<string, OSDestination>> = new Map();
   private readonly logger: Logger;
 
@@ -35,41 +44,45 @@ export class MockOpenSearchBackend implements OpenSearchBackend {
 
   // --- Monitors ---
 
-  async getMonitors(ds: Datasource): Promise<OSMonitor[]> {
-    return Array.from(this.monitors.get(ds.id)?.values() ?? []);
+  async getMonitors(_client: AlertingOSClient): Promise<OSMonitor[]> {
+    return Array.from(this.monitors.get(MOCK_KEY)?.values() ?? []);
   }
 
-  async getMonitor(ds: Datasource, monitorId: string): Promise<OSMonitor | null> {
-    return this.monitors.get(ds.id)?.get(monitorId) ?? null;
+  async getMonitor(_client: AlertingOSClient, monitorId: string): Promise<OSMonitor | null> {
+    return this.monitors.get(MOCK_KEY)?.get(monitorId) ?? null;
   }
 
-  async createMonitor(ds: Datasource, input: Omit<OSMonitor, 'id'>): Promise<OSMonitor> {
+  async createMonitor(_client: AlertingOSClient, input: Omit<OSMonitor, 'id'>): Promise<OSMonitor> {
     const id = nextId();
     const monitor: OSMonitor = { ...input, id };
-    if (!this.monitors.has(ds.id)) this.monitors.set(ds.id, new Map());
-    this.monitors.get(ds.id)!.set(id, monitor);
-    this.logger.info(`[OS Mock] Created monitor ${id} for ${ds.id}`);
+    if (!this.monitors.has(MOCK_KEY)) this.monitors.set(MOCK_KEY, new Map());
+    this.monitors.get(MOCK_KEY)!.set(id, monitor);
+    this.logger.info(`[OS Mock] Created monitor ${id}`);
     return monitor;
   }
 
   async updateMonitor(
-    ds: Datasource,
+    _client: AlertingOSClient,
     monitorId: string,
     input: Partial<OSMonitor>
   ): Promise<OSMonitor | null> {
-    const m = this.monitors.get(ds.id)?.get(monitorId);
+    const m = this.monitors.get(MOCK_KEY)?.get(monitorId);
     if (!m) return null;
     Object.assign(m, input, { last_update_time: Date.now() });
     return m;
   }
 
-  async deleteMonitor(ds: Datasource, monitorId: string): Promise<boolean> {
-    return this.monitors.get(ds.id)?.delete(monitorId) ?? false;
+  async deleteMonitor(_client: AlertingOSClient, monitorId: string): Promise<boolean> {
+    return this.monitors.get(MOCK_KEY)?.delete(monitorId) ?? false;
   }
 
-  async runMonitor(ds: Datasource, monitorId: string, _dryRun?: boolean): Promise<unknown> {
+  async runMonitor(
+    _client: AlertingOSClient,
+    monitorId: string,
+    _dryRun?: boolean
+  ): Promise<unknown> {
     // Return a realistic execution result based on monitor type
-    const monitor = this.monitors.get(ds.id)?.get(monitorId);
+    const monitor = this.monitors.get(MOCK_KEY)?.get(monitorId);
     if (monitor) {
       const input = monitor.inputs[0];
       if (input && 'uri' in input) {
@@ -120,7 +133,7 @@ export class MockOpenSearchBackend implements OpenSearchBackend {
   }
 
   async searchQuery(
-    _ds: Datasource,
+    _client: AlertingOSClient,
     _indices: string[],
     _body: Record<string, unknown>
   ): Promise<unknown> {
@@ -148,13 +161,17 @@ export class MockOpenSearchBackend implements OpenSearchBackend {
 
   // --- Alerts ---
 
-  async getAlerts(ds: Datasource): Promise<{ alerts: OSAlert[]; totalAlerts: number }> {
-    const alerts = this.alerts.get(ds.id) ?? [];
+  async getAlerts(_client: AlertingOSClient): Promise<{ alerts: OSAlert[]; totalAlerts: number }> {
+    const alerts = this.alerts.get(MOCK_KEY) ?? [];
     return { alerts, totalAlerts: alerts.length };
   }
 
-  async acknowledgeAlerts(ds: Datasource, _monitorId: string, alertIds: string[]): Promise<any> {
-    const alerts = this.alerts.get(ds.id) ?? [];
+  async acknowledgeAlerts(
+    _client: AlertingOSClient,
+    _monitorId: string,
+    alertIds: string[]
+  ): Promise<unknown> {
+    const alerts = this.alerts.get(MOCK_KEY) ?? [];
     for (const a of alerts) {
       if (alertIds.includes(a.id)) {
         a.state = 'ACKNOWLEDGED';
@@ -166,23 +183,23 @@ export class MockOpenSearchBackend implements OpenSearchBackend {
 
   // --- Destinations ---
 
-  async getDestinations(ds: Datasource): Promise<OSDestination[]> {
-    return Array.from(this.destinations.get(ds.id)?.values() ?? []);
+  async getDestinations(_client: AlertingOSClient): Promise<OSDestination[]> {
+    return Array.from(this.destinations.get(MOCK_KEY)?.values() ?? []);
   }
 
   async createDestination(
-    ds: Datasource,
+    _client: AlertingOSClient,
     input: Omit<OSDestination, 'id'>
   ): Promise<OSDestination> {
     const id = nextId();
     const dest: OSDestination = { ...input, id };
-    if (!this.destinations.has(ds.id)) this.destinations.set(ds.id, new Map());
-    this.destinations.get(ds.id)!.set(id, dest);
+    if (!this.destinations.has(MOCK_KEY)) this.destinations.set(MOCK_KEY, new Map());
+    this.destinations.get(MOCK_KEY)!.set(id, dest);
     return dest;
   }
 
-  async deleteDestination(ds: Datasource, destId: string): Promise<boolean> {
-    return this.destinations.get(ds.id)?.delete(destId) ?? false;
+  async deleteDestination(_client: AlertingOSClient, destId: string): Promise<boolean> {
+    return this.destinations.get(MOCK_KEY)?.delete(destId) ?? false;
   }
 
   // --- Seeding ---

--- a/server/services/alerting/mock_prometheus_backend.ts
+++ b/server/services/alerting/mock_prometheus_backend.ts
@@ -489,24 +489,3 @@ function inferMetricType(name: string): PrometheusMetricMetadata['type'] {
   if (name.includes('duration') || name.includes('latency')) return 'histogram';
   return 'gauge'; // default assumption for unknown metrics
 }
-
-// ============================================================================
-// Helpers
-// ============================================================================
-/** Infer Prometheus metric type from name suffix heuristics. */
-function inferMetricType(name: string): PrometheusMetricMetadata['type'] {
-  if (name.endsWith('_total') || name.endsWith('_count')) return 'counter';
-  if (name.endsWith('_bucket')) return 'histogram';
-  if (name.endsWith('_sum')) return 'counter'; // histogram/summary sub-metric
-  if (
-    name.endsWith('_bytes') ||
-    name.endsWith('_seconds') ||
-    name.endsWith('_ratio') ||
-    name.endsWith('_percent') ||
-    name.endsWith('_info') ||
-    name === 'up'
-  )
-    return 'gauge';
-  if (name.includes('duration') || name.includes('latency')) return 'histogram';
-  return 'gauge'; // default assumption for unknown metrics
-}

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -9,6 +9,7 @@
  * API reference: https://opensearch.org/docs/latest/observing-your-data/alerting/api/
  */
 import {
+  AlertingOSClient,
   Logger,
   OpenSearchBackend,
   OSMonitor,
@@ -36,7 +37,7 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
   // Monitors
   // =========================================================================
 
-  async getMonitors(client: any): Promise<OSMonitor[]> {
+  async getMonitors(client: AlertingOSClient): Promise<OSMonitor[]> {
     const PAGE_SIZE = 100;
     const monitors: OSMonitor[] = [];
     let searchAfter: unknown[] | undefined;
@@ -72,7 +73,7 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
     return monitors;
   }
 
-  async getMonitor(client: any, monitorId: string): Promise<OSMonitor | null> {
+  async getMonitor(client: AlertingOSClient, monitorId: string): Promise<OSMonitor | null> {
     try {
       const resp = await this.req<OSGetMonitorResponse>(
         client,
@@ -86,7 +87,10 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
     }
   }
 
-  async createMonitor(client: any, monitor: Omit<OSMonitor, 'id'>): Promise<OSMonitor> {
+  async createMonitor(
+    client: AlertingOSClient,
+    monitor: Omit<OSMonitor, 'id'>
+  ): Promise<OSMonitor> {
     const resp = await this.req<OSCreateMonitorResponse>(
       client,
       'POST',
@@ -100,7 +104,7 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
   }
 
   async updateMonitor(
-    client: any,
+    client: AlertingOSClient,
     monitorId: string,
     input: Partial<OSMonitor>
   ): Promise<OSMonitor | null> {
@@ -136,7 +140,7 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
     }
   }
 
-  async deleteMonitor(client: any, monitorId: string): Promise<boolean> {
+  async deleteMonitor(client: AlertingOSClient, monitorId: string): Promise<boolean> {
     try {
       await this.req(client, 'DELETE', `/_plugins/_alerting/monitors/${monitorId}`);
       return true;


### PR DESCRIPTION
## Summary

Follow-up refactor on top of #2653 (still WIP). Three logical commits, no functional changes to shipped behavior:

1. **`fix(alerting): correctness fixes blocking the PR`** — three pre-existing bugs that would break first use:
   - Public components imported types across the plugin boundary (`public/` → `server/services/alerting`), bundling server types into the browser. Route everything through `common/types/alerting` and strip the server barrel's type re-exports.
   - `AlarmsApiClient` monitor CRUD defaulted `dsId` to `'ds-1'` when the caller didn't pass one — silently posting to a nonexistent datasource. Make `dsId` required, resolve it at each callsite, and surface "select a datasource" toasts when empty.
   - `alertmanager_handlers.ts` imports `js-yaml` but the plugin's `package.json` didn't declare it — was resolving transitively from the OSD root. Declare `js-yaml` + `@types/js-yaml` to match the root workspace pin.

2. **`refactor(alerting): reuse existing plugin utilities`** — three code-dedup swaps to align with how the rest of the plugin works:
   - Replace local toast state + `EuiGlobalToastList` wiring with the shared `useToast` hook from `public/components/common/toast` (signatures match).
   - Replace the two `EuiConfirmModal` instances that actually delete monitors with the shared `DeleteModal` from `public/components/common/helpers` (requires typing "delete" to confirm, consistent with notebooks/dashboards).
   - `AlertingHome` drilled `CoreStart` through props just to construct `AlarmsApiClient`. Read `coreRefs.http` directly like every other observability feature does.

3. **`refactor(alerting): clean up types and organization`** — close out the typecheck gaps and unlock unit tests:
   - Extract `transformLogsFormToPayload` / `transformMetricsFormToPayload` (~95 lines) from `alarms_page.tsx` into `common/services/alerting/form_transforms.ts`. Pure functions with no React/coreRefs/Node deps.
   - Change `OpenSearchBackend` interface to take the scoped `AlertingOSClient` directly instead of `Datasource` (the caller already resolves the per-request client; datasource identity is baked in). Propagate through `HttpOpenSearchBackend`, `MockOpenSearchBackend`, `alert_service.ts`. Remove a duplicate `inferMetricType`. Type `datasourceService` as `InMemoryDatasourceService` at the route wiring site so `.seed()` resolves. Add a `toErrorBody` adapter that maps framework-agnostic `{ error: 'string' }` handler results to OSD's `ResponseError` shape.
   - Enforce a Summary/Full split on the public side: list-view state (`alarms_page.alerts/rules`, flyout props) now types as `UnifiedAlertSummary` / `UnifiedRuleSummary`. Detail flyouts already re-fetch the full shape via `getAlertDetail` / `getRuleDetail`, so downstream code can't accidentally reach into detail-only fields off summary data. Type `EuiBasicTable` column arrays with their row type; thread an explicit `EChartsOption` through the bar-chart memos.

Net effect: zero TypeScript errors in the alerting subdirectory (down from 55 pre-existing).

## Test plan

- [ ] Typecheck passes: `yarn typecheck` (verified locally, zero alerting errors)
- [ ] Smoke test the alerting UI in a dev server — create/edit/delete a monitor, acknowledge an alert, view the routing tab
- [ ] Confirm toasts still appear via `coreRefs.toasts` (success + danger + warning paths)
- [ ] Confirm delete confirmation now requires typing "delete"
- [ ] Regression check: no imports from `server/` in `public/` (`grep -rn "from '.*server" public/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)