### PR TITLE
Alert Manager: add Prometheus datasource selector to Routing tab

### DIFF
--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -653,7 +653,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({ apiClient }) => {
       );
     }
     if (activeTab === 'routing') {
-      return <NotificationRoutingPanel apiClient={apiClient} />;
+      return <NotificationRoutingPanel apiClient={apiClient} datasources={datasources} />;
     }
     return null;
   };

--- a/public/components/alerting/notification_routing_panel.tsx
+++ b/public/components/alerting/notification_routing_panel.tsx
@@ -200,6 +200,20 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
     fetchConfig();
   }, [fetchConfig]);
 
+  // Disambiguate duplicate names by appending the id — two Prom connections
+  // can share a `name` across MDS clusters, and the dropdown would otherwise
+  // show indistinguishable entries.
+  const selectorOptions = useMemo(() => {
+    const nameCounts = promDatasources.reduce<Record<string, number>>((acc, d) => {
+      acc[d.name] = (acc[d.name] || 0) + 1;
+      return acc;
+    }, {});
+    return promDatasources.map((d) => ({
+      value: datasourceKey(d),
+      text: nameCounts[d.name] > 1 ? `${d.name} (${d.id})` : d.name,
+    }));
+  }, [promDatasources, datasourceKey]);
+
   // Compact Prometheus datasource selector. Always rendered when a Prom DS
   // is available so the user can see which source the Alertmanager config is
   // coming from; disabled when there's only one (nothing to switch to).
@@ -207,7 +221,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
     promDatasources.length > 0 && selectedDsId ? (
       <EuiCompressedSelect
         prepend="Source"
-        options={promDatasources.map((d) => ({ value: datasourceKey(d), text: d.name }))}
+        options={selectorOptions}
         value={selectedDsId}
         onChange={(e) => setSelectedDsId(e.target.value)}
         disabled={promDatasources.length === 1}
@@ -219,11 +233,21 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
 
   if (loading) {
     return (
-      <EuiFlexGroup justifyContent="center" style={{ padding: 40 }}>
-        <EuiFlexItem grow={false}>
-          <EuiLoadingSpinner size="xl" />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <div style={{ padding: '0 16px' }}>
+        {datasourceSelector && (
+          <>
+            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+              <EuiFlexItem grow={false}>{datasourceSelector}</EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <EuiFlexGroup justifyContent="center" style={{ padding: 40 }}>
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="xl" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
     );
   }
 

--- a/public/components/alerting/notification_routing_panel.tsx
+++ b/public/components/alerting/notification_routing_panel.tsx
@@ -9,13 +9,14 @@
  * OpenSearch Direct Query API proxy) and displays the route tree, receivers,
  * and inhibit rules.
  */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiBadge,
   EuiButtonIcon,
   EuiCallOut,
+  EuiCompressedSelect,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -27,6 +28,7 @@ import {
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
+import { Datasource } from '../../../common/types/alerting';
 import { AlarmsApiClient } from './services/alarms_client';
 
 // ---------------------------------------------------------------------------
@@ -148,11 +150,34 @@ const INTEGRATION_COLORS: Record<string, string> = {
 
 export interface NotificationRoutingPanelProps {
   apiClient: AlarmsApiClient;
+  datasources: Datasource[];
 }
 
 export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> = ({
   apiClient,
+  datasources,
 }) => {
+  // Alertmanager is reached through a single Prometheus datasource at a time —
+  // only parent Prom entries are candidates (workspace-derived entries share
+  // the same Alertmanager endpoint as their parent).
+  const promDatasources = useMemo(
+    () => datasources.filter((d) => d.type === 'prometheus' && !d.parentDatasourceId),
+    [datasources]
+  );
+  // Key selection off `directQueryName` (or `name`) rather than `id`, because
+  // `id` is regenerated on every server-side datasource rediscovery cycle.
+  const datasourceKey = useCallback((d: Datasource): string => d.directQueryName || d.name, []);
+  const [selectedDsId, setSelectedDsId] = useState<string | undefined>(undefined);
+
+  // Default to the first Prom datasource once loaded; preserve user choice across reloads.
+  useEffect(() => {
+    if (promDatasources.length === 0) return;
+    const stillValid = promDatasources.some((d) => datasourceKey(d) === selectedDsId);
+    if (!selectedDsId || !stillValid) {
+      setSelectedDsId(datasourceKey(promDatasources[0]));
+    }
+  }, [promDatasources, selectedDsId, datasourceKey]);
+
   const [config, setConfig] = useState<AlertmanagerConfig | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -161,7 +186,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
     setLoading(true);
     setError(null);
     try {
-      const res = await apiClient.getAlertmanagerConfig();
+      const res = await apiClient.getAlertmanagerConfig(selectedDsId);
       // The API client types route/inhibitRules as `unknown` because it's
       // handed back raw from Alertmanager; narrow to our local shape here.
       setConfig((res as unknown) as AlertmanagerConfig);
@@ -169,11 +194,28 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
       setError(e instanceof Error ? e.message : 'Failed to fetch Alertmanager config');
     }
     setLoading(false);
-  }, [apiClient]);
+  }, [apiClient, selectedDsId]);
 
   useEffect(() => {
     fetchConfig();
   }, [fetchConfig]);
+
+  // Compact Prometheus datasource selector. Always rendered when a Prom DS
+  // is available so the user can see which source the Alertmanager config is
+  // coming from; disabled when there's only one (nothing to switch to).
+  const datasourceSelector =
+    promDatasources.length > 0 && selectedDsId ? (
+      <EuiCompressedSelect
+        prepend="Source"
+        options={promDatasources.map((d) => ({ value: datasourceKey(d), text: d.name }))}
+        value={selectedDsId}
+        onChange={(e) => setSelectedDsId(e.target.value)}
+        disabled={promDatasources.length === 1}
+        aria-label="Prometheus datasource"
+        data-test-subj="alertManager-routing-datasourceSelect"
+        style={{ minWidth: 220 }}
+      />
+    ) : null;
 
   if (loading) {
     return (
@@ -187,32 +229,54 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
 
   if (error) {
     return (
-      <EuiCallOut title="Error loading Alertmanager config" color="danger" iconType="alert">
-        {error}
-      </EuiCallOut>
+      <div style={{ padding: '0 16px' }}>
+        {datasourceSelector && (
+          <>
+            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+              <EuiFlexItem grow={false}>{datasourceSelector}</EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <EuiCallOut title="Error loading Alertmanager config" color="danger" iconType="alert">
+          {error}
+        </EuiCallOut>
+      </div>
     );
   }
 
   if (!config?.available) {
     return (
-      <EuiEmptyPrompt
-        iconType="bell"
-        title={<h2>Alertmanager Not Available</h2>}
-        body={
-          <p>
-            No Alertmanager is connected. Ensure your Prometheus datasource in the OpenSearch SQL
-            plugin has <code>alertmanager.uri</code> configured in its properties.
-          </p>
-        }
-      />
+      <div style={{ padding: '0 16px' }}>
+        {datasourceSelector && (
+          <>
+            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+              <EuiFlexItem grow={false}>{datasourceSelector}</EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <EuiEmptyPrompt
+          iconType="bell"
+          title={<h2>Alertmanager Not Available</h2>}
+          body={
+            <p>
+              No Alertmanager is connected. Ensure your Prometheus datasource in the OpenSearch SQL
+              plugin has <code>alertmanager.uri</code> configured in its properties.
+            </p>
+          }
+        />
+      </div>
     );
   }
 
   if (config.configParseError) {
     return (
-      <EuiCallOut title="Failed to parse Alertmanager config" color="warning" iconType="alert">
-        <p>{config.configParseError}</p>
-      </EuiCallOut>
+      <div style={{ padding: '0 16px' }}>
+        <EuiCallOut title="Failed to parse Alertmanager config" color="warning" iconType="alert">
+          <p>{config.configParseError}</p>
+        </EuiCallOut>
+      </div>
     );
   }
 
@@ -353,7 +417,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
   ];
 
   return (
-    <div>
+    <div style={{ padding: '0 16px' }}>
       {/* Read-only explanation banner (UX audit M6 + S-m8) */}
       <EuiCallOut title="Read-only view" color="primary" iconType="iInCircle" size="s">
         <p>
@@ -387,6 +451,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow />
+          {datasourceSelector && <EuiFlexItem grow={false}>{datasourceSelector}</EuiFlexItem>}
           <EuiFlexItem grow={false}>
             <EuiToolTip content="Refresh">
               <EuiButtonIcon iconType="refresh" aria-label="Refresh" onClick={fetchConfig} />

--- a/public/components/alerting/services/alarms_client.ts
+++ b/public/components/alerting/services/alarms_client.ts
@@ -285,8 +285,11 @@ export class AlarmsApiClient {
 
   // ---- Alertmanager config ------------------------------------------------
 
-  async getAlertmanagerConfig(): Promise<AlertmanagerConfigResponse> {
-    return this.httpGet<AlertmanagerConfigResponse>(this.paths.alertmanagerConfig);
+  async getAlertmanagerConfig(dsId?: string): Promise<AlertmanagerConfigResponse> {
+    return this.httpGet<AlertmanagerConfigResponse>(
+      this.paths.alertmanagerConfig,
+      dsId ? { dsId } : undefined
+    );
   }
 
   // ---- Prometheus Metadata ------------------------------------------------

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -635,24 +635,40 @@ export function registerAlertingRoutes(
   // ===========================================================================
 
   router.get(
-    { path: '/api/alerting/alertmanager/config', validate: {} },
-    async (ctx, _req, res) => {
+    {
+      path: '/api/alerting/alertmanager/config',
+      validate: { query: schema.object({ dsId: schema.maybe(schema.string()) }) },
+    },
+    async (ctx, req, res) => {
       const promBackend = alertService.getPrometheusBackend?.();
       if (!promBackend) {
         return res.ok({ body: { available: false, error: 'Alertmanager not configured' } });
       }
       // Alertmanager is a global endpoint reached through any configured Prometheus
-      // datasource. Pick the first discovered Prom datasource and set it as the
-      // backend's default — the backend uses it to build
-      // /_plugins/_directquery/_resources/{name}/alertmanager/api/v2/status.
+      // datasource. If the caller supplied `dsId`, use that Prom datasource;
+      // otherwise fall back to the first discovered Prom connection. The backend
+      // uses it to build /_plugins/_directquery/_resources/{name}/alertmanager/api/v2/status.
       await discoverOsdDatasources(ctx);
       const all = await datasourceService.list();
-      const promDs = all.find((d) => d.type === 'prometheus' && d.directQueryName);
+      const promCandidates = all.filter((d) => d.type === 'prometheus' && d.directQueryName);
+      // Datasource IDs churn across discovery cycles (in-memory, re-seeded each
+      // discovery pass). Match by `directQueryName` / `name` as a stable fallback
+      // so a selector value the client captured earlier still resolves.
+      const promDs = req.query.dsId
+        ? promCandidates.find(
+            (d) =>
+              d.id === req.query.dsId ||
+              d.directQueryName === req.query.dsId ||
+              d.name === req.query.dsId
+          )
+        : promCandidates[0];
       if (!promDs) {
         return res.ok({
           body: {
             available: false,
-            error: 'No Prometheus datasource configured. Add a Prometheus direct-query connection.',
+            error: req.query.dsId
+              ? `Prometheus datasource "${req.query.dsId}" not found.`
+              : 'No Prometheus datasource configured. Add a Prometheus direct-query connection.',
           },
         });
       }


### PR DESCRIPTION
## Summary

Let users see and switch which Prometheus datasource drives the Routing tab's Alertmanager view.

- **`feat(alerting): add Prometheus datasource selector to Routing tab`** — Alertmanager is a global endpoint reached through one Prometheus datasource at a time, but the Routing panel always picked the first discovered one with no indication of which source produced the displayed route tree, receivers, and inhibit rules.
  - Add a compressed `EuiSelect` (prepend="Source") to the cluster status bar. Enabled when multiple parent Prom datasources exist; disabled (but visible) when there's only one so the source is always apparent.
  - Server-side datasource IDs churn (`ds-N` is reassigned every discovery pass). Key selection off `directQueryName` (the SQL-plugin connection name, stable across restarts), and teach `/api/alerting/alertmanager/config` to match `dsId` against `id` / `directQueryName` / `name`. When the stored selection no longer resolves, fall back to the first candidate.
  - Pad the root container consistently (`0 16px`) across loaded, error, not-available, and parse-error branches — the headings were previously flush against the side nav.

- **`fix(alerting): polish routing-panel source selector`** — review follow-ups on the above:
  - Wrap the loading branch in the same padded container so the selector remains visible (and layout stays consistent) during the Alertmanager fetch.
  - Disambiguate duplicate datasource names by appending `(id)` to the label only when a collision exists. The option value still keys off the stable `directQueryName`, so server matching is unaffected.

## Screenshots with the drop down selector
<img width="1742" height="916" alt="Screenshot 2026-04-22 at 5 50 56 PM" src="https://github.com/user-attachments/assets/1e3e0446-3aab-4ec8-8f8b-24374826d48b" />

<img width="1751" height="920" alt="Screenshot 2026-04-22 at 5 51 03 PM" src="https://github.com/user-attachments/assets/d567b8b5-5777-4b90-8dbb-c7604c83f5c2" />


## Test plan

- [ ] Start a dev server with one Prometheus datasource → selector shows disabled with the single source.
- [ ] Add a second Prometheus datasource via the SQL plugin → selector becomes enabled; switching updates route tree / receivers / inhibit rules.
- [ ] Simulate discovery churn (restart the server) → selector retains the user's choice because the value is keyed off `directQueryName`.
- [ ] Point at a datasource with no `alertmanager.uri` → "Alertmanager Not Available" prompt renders with the selector still visible.
- [ ] Inspect the Routing tab during the initial fetch → selector renders above the spinner (no layout jump) and picks up the first source as the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)