### PR TITLE
fix(alerting): address concurrency, XSS, and error-handling review findings from PR #2653

### DIFF
--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -123,4 +123,64 @@ describe('AlertDetailFlyout', () => {
     fireEvent.click(getByText('Acknowledge'));
     expect(onAcknowledge).not.toHaveBeenCalled();
   });
+
+  describe('runbook URL sanitization', () => {
+    it('does not render the runbook as a link when the URL uses a javascript: protocol', () => {
+      const alertWithBadUrl: UnifiedAlertSummary = {
+        ...baseAlert,
+        annotations: {
+          ...baseAlert.annotations,
+          // eslint-disable-next-line no-script-url
+          runbook_url: 'javascript:alert(document.cookie)',
+        },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={alertWithBadUrl}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const runbookTitle = getByText('Check related runbook');
+      expect(runbookTitle.closest('a')).toBeNull();
+    });
+
+    it('renders the runbook as an external link with rel="noopener noreferrer" for an https URL', () => {
+      const alertWithGoodUrl: UnifiedAlertSummary = {
+        ...baseAlert,
+        annotations: {
+          ...baseAlert.annotations,
+          runbook_url: 'https://runbooks.example.com/high-error-rate',
+        },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={alertWithGoodUrl}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const runbookTitle = getByText('Check related runbook');
+      const anchor = runbookTitle.closest('a');
+      expect(anchor).not.toBeNull();
+      expect(anchor?.getAttribute('href')).toBe('https://runbooks.example.com/high-error-rate');
+      expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+      expect(anchor?.getAttribute('target')).toBe('_blank');
+    });
+
+    it('does not render the runbook as a link when no URL is configured', () => {
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={baseAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const runbookTitle = getByText('Check related runbook');
+      expect(runbookTitle.closest('a')).toBeNull();
+    });
+  });
 });

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -182,5 +182,32 @@ describe('AlertDetailFlyout', () => {
       const runbookTitle = getByText('Check related runbook');
       expect(runbookTitle.closest('a')).toBeNull();
     });
+
+    it('strips embedded basic-auth credentials from the runbook URL', () => {
+      const alertWithCreds: UnifiedAlertSummary = {
+        ...baseAlert,
+        annotations: {
+          ...baseAlert.annotations,
+          runbook_url: 'https://alice:s3cret@runbooks.example.com/page',
+        },
+      };
+      const { getByText, container } = render(
+        <AlertDetailFlyout
+          alert={alertWithCreds}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const runbookTitle = getByText('Check related runbook');
+      const anchor = runbookTitle.closest('a');
+      expect(anchor).not.toBeNull();
+      // Credentials must not appear in href or visible text anywhere.
+      const href = anchor?.getAttribute('href') ?? '';
+      expect(href).toBe('https://runbooks.example.com/page');
+      expect(href).not.toMatch(/alice/);
+      expect(href).not.toMatch(/s3cret/);
+      expect(container.textContent ?? '').not.toMatch(/s3cret/);
+    });
   });
 });

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -32,7 +32,7 @@ import {
 } from '@elastic/eui';
 import { UnifiedAlert, UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
-import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
+import { SEVERITY_COLORS, STATE_COLORS, sanitizeExternalUrl } from './shared_constants';
 
 /** Internal label keys filtered from the Labels accordion display. */
 const INTERNAL_LABEL_KEYS = new Set([
@@ -383,7 +383,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                   </EuiFlexItem>
                   <EuiFlexItem>
                     {hasUrl ? (
-                      <EuiLink href={action.url} target="_blank">
+                      <EuiLink href={action.url} target="_blank" rel="noopener noreferrer">
                         <EuiText size="s">
                           <strong>{action.title}</strong>
                         </EuiText>
@@ -509,14 +509,14 @@ function getSuggestedActions(alert: UnifiedAlertSummary): SuggestedAction[] {
   }
 
   if (alert.severity === 'critical' || alert.severity === 'high') {
-    const runbookUrl = alert.annotations?.runbook_url;
+    const safeRunbookUrl = sanitizeExternalUrl(alert.annotations?.runbook_url);
     actions.push({
       title: 'Check related runbook',
-      description: runbookUrl || 'No runbook URL configured \u2014 consider adding one.',
+      description: safeRunbookUrl || 'No runbook URL configured \u2014 consider adding one.',
       icon: 'document',
       color: 'warning',
-      actionType: runbookUrl ? 'link' : 'manual',
-      url: runbookUrl || undefined,
+      actionType: safeRunbookUrl ? 'link' : 'manual',
+      url: safeRunbookUrl,
     });
   }
 

--- a/public/components/alerting/hooks/__tests__/use_prometheus_metadata.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_prometheus_metadata.test.ts
@@ -122,4 +122,35 @@ describe('usePrometheusMetadata', () => {
       expect(result.current.metricMetadata).toEqual(meta);
     });
   });
+
+  it('does not instantiate the service or fire any fetches when datasourceId is empty', async () => {
+    const { AlertingPromResourcesService } = jest.requireMock(
+      '../../query_services/alerting_prom_resources_service'
+    ) as { AlertingPromResourcesService: jest.Mock };
+    AlertingPromResourcesService.mockClear();
+
+    const { result } = renderHook(() =>
+      usePrometheusMetadata({ datasourceId: '', selectedMetric: 'up' })
+    );
+
+    // Service never constructed.
+    expect(AlertingPromResourcesService).not.toHaveBeenCalled();
+    // No underlying methods invoked.
+    expect(mockGetMetricMetadata).not.toHaveBeenCalled();
+    expect(mockListLabelNames).not.toHaveBeenCalled();
+
+    // Interactions are no-ops while idle.
+    act(() => {
+      result.current.searchMetrics('up');
+      result.current.fetchLabelValues('job');
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(mockListMetricNames).not.toHaveBeenCalled();
+    expect(mockListLabelValues).not.toHaveBeenCalled();
+    expect(result.current.metricOptions).toEqual([]);
+    expect(result.current.labelNames).toEqual([]);
+    expect(result.current.error).toBe(false);
+  });
 });

--- a/public/components/alerting/hooks/use_alerts.ts
+++ b/public/components/alerting/hooks/use_alerts.ts
@@ -4,36 +4,33 @@
  */
 
 /**
- * use_alerts — paginated unified alerts across selected datasources.
- * Wraps AlertingOpenSearchService.listAlerts, APM-style (useMemo service +
- * useEffect fetch).
+ * use_alerts — unified alerts across selected datasources.
+ *
+ * Wraps `AlertingOpenSearchService.listAlerts`, which returns a
+ * `ProgressiveResponse<UnifiedAlertSummary>` (all results with per-datasource
+ * status). The server does not implement page/pageSize pagination on the
+ * unified endpoint; consumers that need pagination should slice
+ * `data.results` client-side.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { PaginatedResponse, UnifiedAlertSummary } from '../../../../common/types/alerting';
+import type { ProgressiveResponse, UnifiedAlertSummary } from '../../../../common/types/alerting';
 import { AlertingOpenSearchService } from '../query_services/alerting_opensearch_service';
 
 export interface UseAlertsParams {
   dsIds: string[];
-  page: number;
-  pageSize: number;
   refreshToken?: unknown;
 }
 
 export interface UseAlertsResult {
-  data: PaginatedResponse<UnifiedAlertSummary> | null;
+  data: ProgressiveResponse<UnifiedAlertSummary> | null;
   isLoading: boolean;
   error: Error | null;
   refetch: () => void;
 }
 
-export function useAlerts({
-  dsIds,
-  page,
-  pageSize,
-  refreshToken,
-}: UseAlertsParams): UseAlertsResult {
+export function useAlerts({ dsIds, refreshToken }: UseAlertsParams): UseAlertsResult {
   const service = useMemo(() => new AlertingOpenSearchService(), []);
-  const [data, setData] = useState<PaginatedResponse<UnifiedAlertSummary> | null>(null);
+  const [data, setData] = useState<ProgressiveResponse<UnifiedAlertSummary> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [localRefresh, setLocalRefresh] = useState(0);
@@ -51,7 +48,7 @@ export function useAlerts({
     setError(null);
     (async () => {
       try {
-        const res = await service.listAlerts({ dsIds, page, pageSize });
+        const res = await service.listAlerts({ dsIds });
         if (!cancelled) setData(res);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
@@ -62,8 +59,9 @@ export function useAlerts({
     return () => {
       cancelled = true;
     };
+    // `dsIds` is a new array reference each render; `dsIdsKey` is its stable projection.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [service, dsIdsKey, page, pageSize, refreshToken, localRefresh]);
+  }, [service, dsIdsKey, refreshToken, localRefresh]);
 
   return { data, isLoading, error, refetch };
 }

--- a/public/components/alerting/hooks/use_prometheus_metadata.ts
+++ b/public/components/alerting/hooks/use_prometheus_metadata.ts
@@ -148,7 +148,12 @@ export function usePrometheusMetadata(
   options: UsePrometheusMetadataOptions
 ): UsePrometheusMetadataReturn {
   const { datasourceId, selectedMetric } = options;
-  const service = useMemo(() => new AlertingPromResourcesService(datasourceId), [datasourceId]);
+  // Don't instantiate the service when no datasource is selected — the
+  // constructor now rejects empty strings. Effects short-circuit on `!service`.
+  const service = useMemo(
+    () => (datasourceId ? new AlertingPromResourcesService(datasourceId) : null),
+    [datasourceId]
+  );
   const [state, dispatch] = useReducer(metadataReducer, initialState);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -162,6 +167,7 @@ export function usePrometheusMetadata(
   const searchMetrics = useCallback(
     (query: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (!service) return;
 
       if (query.length < MIN_SEARCH_CHARS) {
         dispatch({ type: 'METRICS_LOADED', options: [] });
@@ -194,7 +200,7 @@ export function usePrometheusMetadata(
       return;
     }
 
-    if (!selectedMetric) return;
+    if (!selectedMetric || !service) return;
 
     dispatch({ type: 'LABELS_LOADING' });
     dispatch({ type: 'CLEAR_LABEL_VALUES' });
@@ -221,6 +227,7 @@ export function usePrometheusMetadata(
   // ------------------------------------------------------------------
 
   useEffect(() => {
+    if (!service) return;
     let cancelled = false;
     (async () => {
       try {
@@ -228,8 +235,11 @@ export function usePrometheusMetadata(
         if (!cancelled) {
           dispatch({ type: 'METADATA_LOADED', metadata: res.metadata });
         }
-      } catch {
-        // Non-critical — metadata is used for type badges only
+      } catch (err) {
+        // Non-critical — metadata is used for type badges only. Log so the
+        // failure is visible in console instead of silently swallowed.
+
+        console.warn('Prometheus metric metadata fetch failed:', err);
       }
     })();
     return () => {
@@ -243,7 +253,7 @@ export function usePrometheusMetadata(
 
   const fetchLabelValues = useCallback(
     (labelName: string) => {
-      if (!labelName) return;
+      if (!labelName || !service) return;
 
       dispatch({ type: 'LABEL_VALUES_LOADING', labelName });
       const selector =

--- a/public/components/alerting/hooks/use_rules.ts
+++ b/public/components/alerting/hooks/use_rules.ts
@@ -3,28 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** use_rules — paginated unified rules across selected datasources. */
+/**
+ * use_rules — unified rules across selected datasources.
+ *
+ * Wraps `AlertingOpenSearchService.listRules`, which returns a
+ * `ProgressiveResponse<UnifiedRuleSummary>` (all results with per-datasource
+ * status). The server does not implement page/pageSize pagination on the
+ * unified endpoint; consumers that need pagination should slice
+ * `data.results` client-side.
+ */
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { PaginatedResponse, UnifiedRuleSummary } from '../../../../common/types/alerting';
+import type { ProgressiveResponse, UnifiedRuleSummary } from '../../../../common/types/alerting';
 import { AlertingOpenSearchService } from '../query_services/alerting_opensearch_service';
 
 export interface UseRulesParams {
   dsIds: string[];
-  page: number;
-  pageSize: number;
   refreshToken?: unknown;
 }
 
 export interface UseRulesResult {
-  data: PaginatedResponse<UnifiedRuleSummary> | null;
+  data: ProgressiveResponse<UnifiedRuleSummary> | null;
   isLoading: boolean;
   error: Error | null;
   refetch: () => void;
 }
 
-export function useRules({ dsIds, page, pageSize, refreshToken }: UseRulesParams): UseRulesResult {
+export function useRules({ dsIds, refreshToken }: UseRulesParams): UseRulesResult {
   const service = useMemo(() => new AlertingOpenSearchService(), []);
-  const [data, setData] = useState<PaginatedResponse<UnifiedRuleSummary> | null>(null);
+  const [data, setData] = useState<ProgressiveResponse<UnifiedRuleSummary> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [localRefresh, setLocalRefresh] = useState(0);
@@ -42,7 +48,7 @@ export function useRules({ dsIds, page, pageSize, refreshToken }: UseRulesParams
     setError(null);
     (async () => {
       try {
-        const res = await service.listRules({ dsIds, page, pageSize });
+        const res = await service.listRules({ dsIds });
         if (!cancelled) setData(res);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
@@ -53,8 +59,9 @@ export function useRules({ dsIds, page, pageSize, refreshToken }: UseRulesParams
     return () => {
       cancelled = true;
     };
+    // `dsIds` is a new array reference each render; `dsIdsKey` is its stable projection.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [service, dsIdsKey, page, pageSize, refreshToken, localRefresh]);
+  }, [service, dsIdsKey, refreshToken, localRefresh]);
 
   return { data, isLoading, error, refetch };
 }

--- a/public/components/alerting/query_services/__tests__/alerting_prom_resources_service.test.ts
+++ b/public/components/alerting/query_services/__tests__/alerting_prom_resources_service.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AlertingPromResourcesService } from '../alerting_prom_resources_service';
+
+describe('AlertingPromResourcesService', () => {
+  it('constructs with a non-empty datasource id', () => {
+    expect(() => new AlertingPromResourcesService('ds-1')).not.toThrow();
+  });
+
+  it('throws when constructed with an empty datasource id', () => {
+    expect(() => new AlertingPromResourcesService('')).toThrow(/datasourceId is required/);
+  });
+
+  it('throws when constructed with a non-string datasource id', () => {
+    // Force a runtime bad value through the constructor — covers the
+    // "silent bad-URL request against /api/alerting/prometheus/undefined/..."
+    // failure mode. The `as` cast mirrors what real call sites can produce
+    // at runtime even though TypeScript types say `string`.
+    expect(() => new AlertingPromResourcesService((undefined as unknown) as string)).toThrow(
+      /datasourceId is required/
+    );
+  });
+});

--- a/public/components/alerting/query_services/alerting_prom_resources_service.ts
+++ b/public/components/alerting/query_services/alerting_prom_resources_service.ts
@@ -18,7 +18,11 @@ import { coreRefs } from '../../../framework/core_refs';
 import type { PrometheusMetricMetadata } from '../../../../common/types/alerting';
 
 export class AlertingPromResourcesService {
-  constructor(private readonly datasourceId: string) {}
+  constructor(private readonly datasourceId: string) {
+    if (!datasourceId || typeof datasourceId !== 'string') {
+      throw new Error('datasourceId is required for AlertingPromResourcesService');
+    }
+  }
 
   private requireHttp() {
     const http = coreRefs.http;

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -249,6 +249,25 @@ export function escapeHtml(str: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * Validate an externally sourced URL (e.g. a runbook URL pulled from an alert
+ * annotation) before using it in an `href`. Allows only `http:` and `https:`.
+ * Returns `undefined` when the input is missing, unparseable, or uses a
+ * disallowed protocol — blocks `javascript:`, `data:`, `file:`, etc.
+ */
+export function sanitizeExternalUrl(url: string | undefined): string | undefined {
+  if (!url || typeof url !== 'string') return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.href;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // ============================================================================
 // Collection utilities
 // ============================================================================

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -253,16 +253,22 @@ export function escapeHtml(str: string): string {
  * Validate an externally sourced URL (e.g. a runbook URL pulled from an alert
  * annotation) before using it in an `href`. Allows only `http:` and `https:`.
  * Returns `undefined` when the input is missing, unparseable, or uses a
- * disallowed protocol — blocks `javascript:`, `data:`, `file:`, etc.
+ * disallowed protocol — blocks `javascript:`, `data:`, `file:`, etc. Strips
+ * embedded credentials (`http://user:pass@host/...`) before returning so they
+ * never surface in the rendered link or description text.
  */
 export function sanitizeExternalUrl(url: string | undefined): string | undefined {
   if (!url || typeof url !== 'string') return undefined;
   try {
     const parsed = new URL(url);
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return parsed.href;
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return undefined;
     }
-    return undefined;
+    // An annotation author could embed basic-auth creds (intentionally or by
+    // mistake). We must not render those in the UI.
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
   } catch {
     return undefined;
   }

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -28,8 +28,16 @@ import { Main as NotebooksHome } from './notebooks/components/main';
 import { Home as TraceAnalyticsHome } from './trace_analytics/home';
 import { Home as GettingStartedHome } from './getting_started/home';
 import { Home as OverviewHome } from './overview/home';
-import { AlertingHome } from './alerting/home';
 import { Services as ApmServices, ApmServicesProps } from './apm/services';
+
+// Lazy-load AlertingHome so the Alert Manager bundle is only fetched when the
+// feature flag is on and the user actually navigates to that app. The app
+// registration itself is gated on `config.alertManager.enabled` in `plugin.tsx`,
+// but an eager import still pulls the alerting code into the main observability
+// chunk for every user. React.lazy defers that fetch.
+const AlertingHome = React.lazy(() =>
+  import('./alerting/home').then((module) => ({ default: module.AlertingHome }))
+);
 import {
   ApplicationMapPage as ApmApplicationMap,
   ApplicationMapPageProps as ApmApplicationMapProps,
@@ -116,31 +124,33 @@ export const App = ({
     <Provider store={store}>
       <I18nProvider>
         <MetricsListener http={http}>
-          <ModuleComponent
-            http={http}
-            chrome={chrome}
-            notifications={notifications}
-            CoreStartProp={CoreStartProp}
-            DepsStart={DepsStart}
-            DashboardContainerByValueRenderer={
-              DepsStart.dashboard.DashboardContainerByValueRenderer
-            }
-            pplService={pplService}
-            dslService={dslService}
-            mlCommonsRCFService={mlCommonsRCFService}
-            savedObjects={savedObjects}
-            timestampUtils={timestampUtils}
-            queryManager={queryManager}
-            parentBreadcrumb={parentBreadcrumb}
-            parentBreadcrumbs={[parentBreadcrumb]}
-            setBreadcrumbs={chrome.setBreadcrumbs}
-            dataSourcePluggables={dataSourcePluggables}
-            dataSourceManagement={dataSourceManagement}
-            dataSourceEnabled={dataSourceEnabled}
-            setActionMenu={setActionMenu}
-            savedObjectsMDSClient={savedObjectsMDSClient}
-            defaultRoute={defaultRoute}
-          />
+          <React.Suspense fallback={<div />}>
+            <ModuleComponent
+              http={http}
+              chrome={chrome}
+              notifications={notifications}
+              CoreStartProp={CoreStartProp}
+              DepsStart={DepsStart}
+              DashboardContainerByValueRenderer={
+                DepsStart.dashboard.DashboardContainerByValueRenderer
+              }
+              pplService={pplService}
+              dslService={dslService}
+              mlCommonsRCFService={mlCommonsRCFService}
+              savedObjects={savedObjects}
+              timestampUtils={timestampUtils}
+              queryManager={queryManager}
+              parentBreadcrumb={parentBreadcrumb}
+              parentBreadcrumbs={[parentBreadcrumb]}
+              setBreadcrumbs={chrome.setBreadcrumbs}
+              dataSourcePluggables={dataSourcePluggables}
+              dataSourceManagement={dataSourceManagement}
+              dataSourceEnabled={dataSourceEnabled}
+              setActionMenu={setActionMenu}
+              savedObjectsMDSClient={savedObjectsMDSClient}
+              defaultRoute={defaultRoute}
+            />
+          </React.Suspense>
         </MetricsListener>
       </I18nProvider>
     </Provider>

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -29,6 +29,11 @@ import { Home as TraceAnalyticsHome } from './trace_analytics/home';
 import { Home as GettingStartedHome } from './getting_started/home';
 import { Home as OverviewHome } from './overview/home';
 import { Services as ApmServices, ApmServicesProps } from './apm/services';
+import {
+  ApplicationMapPage as ApmApplicationMap,
+  ApplicationMapPageProps as ApmApplicationMapProps,
+} from './apm/pages/application_map';
+import { ApmConfigProvider } from './apm/config/apm_config_context';
 
 // Lazy-load AlertingHome so the Alert Manager bundle is only fetched when the
 // feature flag is on and the user actually navigates to that app. The app
@@ -38,11 +43,6 @@ import { Services as ApmServices, ApmServicesProps } from './apm/services';
 const AlertingHome = React.lazy(() =>
   import('./alerting/home').then((module) => ({ default: module.AlertingHome }))
 );
-import {
-  ApplicationMapPage as ApmApplicationMap,
-  ApplicationMapPageProps as ApmApplicationMapProps,
-} from './apm/pages/application_map';
-import { ApmConfigProvider } from './apm/config/apm_config_context';
 
 interface ObservabilityAppDeps {
   CoreStartProp: CoreStart;

--- a/server/routes/alerting/__tests__/alertmanager_handlers.test.ts
+++ b/server/routes/alerting/__tests__/alertmanager_handlers.test.ts
@@ -94,6 +94,7 @@ inhibit_rules: []
     const result = await handleGetAlertmanagerConfig(backend, mockClient, mockDs);
     expect(result.status).toBe(200);
     expect(result.body.available).toBe(true);
+    expect(result.body.code).toBe('ok');
     expect(result.body.cluster).toEqual({
       status: 'ready',
       peers: ['a', 'b'],
@@ -121,19 +122,55 @@ inhibit_rules: []
     expect(result.body.configParseError).toMatch(/Failed to parse YAML/);
   });
 
-  it('returns available:false when backend cannot provide Alertmanager status', async () => {
+  it('returns available:false with code=not_configured when backend cannot provide Alertmanager status', async () => {
     const backend = ({} as unknown) as PrometheusBackend;
     const result = await handleGetAlertmanagerConfig(backend, mockClient, mockDs);
     expect(result.status).toBe(200);
-    expect(result.body).toEqual({ available: false, error: 'Alertmanager not configured' });
+    expect(result.body).toEqual({
+      available: false,
+      code: 'not_configured',
+      error: 'Alertmanager not configured',
+    });
   });
 
-  it('returns available:false with message when upstream throws', async () => {
+  it('maps upstream 401 to HTTP 401 with code=unauthorized and a safe message', async () => {
+    const err = Object.assign(new Error('auth header missing in upstream'), { statusCode: 401 });
     const backend = makeBackend({
-      getAlertmanagerStatus: jest.fn().mockRejectedValue(new Error('connection refused')),
+      getAlertmanagerStatus: jest.fn().mockRejectedValue(err),
     });
     const result = await handleGetAlertmanagerConfig(backend, mockClient, mockDs);
-    expect(result.status).toBe(200);
-    expect(result.body).toEqual({ available: false, error: 'connection refused' });
+    expect(result.status).toBe(401);
+    expect(result.body).toEqual({
+      available: false,
+      code: 'unauthorized',
+      error: 'Unauthorized',
+    });
+    // The original "auth header missing in upstream" must NOT appear in the response.
+    expect(JSON.stringify(result.body)).not.toContain('auth header missing');
+  });
+
+  it('maps upstream 403 to HTTP 403 with code=unauthorized', async () => {
+    const err = Object.assign(new Error('forbidden'), { statusCode: 403 });
+    const backend = makeBackend({
+      getAlertmanagerStatus: jest.fn().mockRejectedValue(err),
+    });
+    const result = await handleGetAlertmanagerConfig(backend, mockClient, mockDs);
+    expect(result.status).toBe(403);
+    expect(result.body.code).toBe('unauthorized');
+    expect(result.body.error).toBe('Forbidden');
+  });
+
+  it('maps a generic upstream failure to HTTP 500 with code=upstream_error and a sanitized message', async () => {
+    const backend = makeBackend({
+      getAlertmanagerStatus: jest
+        .fn()
+        .mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.42:9093')),
+    });
+    const result = await handleGetAlertmanagerConfig(backend, mockClient, mockDs);
+    expect(result.status).toBe(500);
+    expect(result.body.code).toBe('upstream_error');
+    expect(result.body.error).toBe('Failed to fetch Alertmanager config');
+    // The IP address from the thrown error must not appear in the response.
+    expect(JSON.stringify(result.body)).not.toContain('10.0.0.42');
   });
 });

--- a/server/routes/alerting/__tests__/index.test.ts
+++ b/server/routes/alerting/__tests__/index.test.ts
@@ -6,7 +6,7 @@
 /**
  * Route-registration smoke tests for `registerAlertingRoutes`.
  *
- * Post-Phase-3 + Phase-5 state the registrar wires:
+ * Post-Phase-5 + concurrency-fix state the registrar wires:
  *   - 4 mutation routes (delegated to `registerAlertingMutationRoutes` —
  *     still observable on the mock router because the delegate uses the
  *     same router instance):
@@ -15,10 +15,14 @@
  *       PUT    /api/alerting/opensearch/{dsId}/monitors/{monitorId}
  *       DELETE /api/alerting/opensearch/{dsId}/monitors/{monitorId}
  *   - 9 read routes + 1 Alertmanager admin route registered inline (10 GETs)
- *   - 4 Prometheus metadata routes inside `if (metadataService)` (4 GETs)
+ *   - 4 Prometheus metadata routes inside `if (enableMetadataRoutes)` (4 GETs)
  *
  * Datasource CRUD routes were deleted in Phase 3 — these tests also assert
  * none of them sneak back in.
+ *
+ * The stateful alerting services are no longer passed in as pre-built
+ * singletons; they're constructed per-request inside the registrar, so the
+ * tests only mock the stateless dependencies (backends, mutation service).
  */
 
 import { registerAlertingRoutes } from '../index';
@@ -36,13 +40,9 @@ const mockRouter = {
 
 const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
 
-// Minimal stubs for the service parameters — registerAlertingRoutes holds
-// references but only invokes methods during request handling, not at
-// registration time, so empty objects are safe at the registration seam.
-const mockAlertService = {} as never;
-const mockMutationSvc = {} as never;
+const mockOsBackend = {} as never;
 const mockPromBackend = {} as never;
-const mockMetadataService = {} as never;
+const mockMutationSvc = {} as never;
 
 describe('registerAlertingRoutes', () => {
   beforeEach(() => {
@@ -52,15 +52,14 @@ describe('registerAlertingRoutes', () => {
     mockRouter.delete.mockClear();
   });
 
-  it('registers all runtime routes when metadata service is provided (14 GET + 4 mutations = 18)', () => {
-    registerAlertingRoutes(
-      mockRouter as never,
-      mockAlertService,
-      mockMutationSvc,
-      mockPromBackend,
-      mockLogger,
-      mockMetadataService
-    );
+  it('registers all runtime routes when metadata routes are enabled (14 GET + 4 mutations = 18)', () => {
+    registerAlertingRoutes(mockRouter as never, {
+      osBackend: mockOsBackend,
+      promBackend: mockPromBackend,
+      mutationSvc: mockMutationSvc,
+      logger: mockLogger,
+      enableMetadataRoutes: true,
+    });
     const total =
       mockRouter.get.mock.calls.length +
       mockRouter.post.mock.calls.length +
@@ -71,14 +70,14 @@ describe('registerAlertingRoutes', () => {
     expect(mockRouter.get.mock.calls.length).toBe(14);
   });
 
-  it('skips the 4 metadata GET routes when no metadata service is provided (10 GET + 4 mutations = 14)', () => {
-    registerAlertingRoutes(
-      mockRouter as never,
-      mockAlertService,
-      mockMutationSvc,
-      mockPromBackend,
-      mockLogger
-    );
+  it('skips the 4 metadata GET routes when enableMetadataRoutes is false (10 GET + 4 mutations = 14)', () => {
+    registerAlertingRoutes(mockRouter as never, {
+      osBackend: mockOsBackend,
+      promBackend: mockPromBackend,
+      mutationSvc: mockMutationSvc,
+      logger: mockLogger,
+      enableMetadataRoutes: false,
+    });
     const total =
       mockRouter.get.mock.calls.length +
       mockRouter.post.mock.calls.length +
@@ -89,13 +88,13 @@ describe('registerAlertingRoutes', () => {
   });
 
   it('registers the 4 surviving mutation paths', () => {
-    registerAlertingRoutes(
-      mockRouter as never,
-      mockAlertService,
-      mockMutationSvc,
-      mockPromBackend,
-      mockLogger
-    );
+    registerAlertingRoutes(mockRouter as never, {
+      osBackend: mockOsBackend,
+      promBackend: mockPromBackend,
+      mutationSvc: mockMutationSvc,
+      logger: mockLogger,
+      enableMetadataRoutes: false,
+    });
     const postPaths = mockRouter.post.mock.calls.map(([c]: [RouteConfig]) => c.path);
     const putPaths = mockRouter.put.mock.calls.map(([c]: [RouteConfig]) => c.path);
     const deletePaths = mockRouter.delete.mock.calls.map(([c]: [RouteConfig]) => c.path);
@@ -107,26 +106,25 @@ describe('registerAlertingRoutes', () => {
   });
 
   it('registers the Alertmanager admin route', () => {
-    registerAlertingRoutes(
-      mockRouter as never,
-      mockAlertService,
-      mockMutationSvc,
-      mockPromBackend,
-      mockLogger
-    );
+    registerAlertingRoutes(mockRouter as never, {
+      osBackend: mockOsBackend,
+      promBackend: mockPromBackend,
+      mutationSvc: mockMutationSvc,
+      logger: mockLogger,
+      enableMetadataRoutes: false,
+    });
     const getPaths = mockRouter.get.mock.calls.map(([c]: [RouteConfig]) => c.path);
     expect(getPaths).toContain('/api/alerting/alertmanager/config');
   });
 
   it('does NOT register deleted datasource CRUD routes', () => {
-    registerAlertingRoutes(
-      mockRouter as never,
-      mockAlertService,
-      mockMutationSvc,
-      mockPromBackend,
-      mockLogger,
-      mockMetadataService
-    );
+    registerAlertingRoutes(mockRouter as never, {
+      osBackend: mockOsBackend,
+      promBackend: mockPromBackend,
+      mutationSvc: mockMutationSvc,
+      logger: mockLogger,
+      enableMetadataRoutes: true,
+    });
     const allPaths = [
       ...mockRouter.get.mock.calls.map(([c]: [RouteConfig]) => c.path),
       ...mockRouter.post.mock.calls.map(([c]: [RouteConfig]) => c.path),

--- a/server/routes/alerting/__tests__/route_utils.test.ts
+++ b/server/routes/alerting/__tests__/route_utils.test.ts
@@ -8,22 +8,41 @@ import {
   createNotFoundError,
   createValidationError,
   createInternalError,
+  createConflictError,
 } from '../../../services/alerting';
+import type { Logger } from '../../../../common/types/alerting';
+
+const makeLogger = (): Logger & {
+  error: jest.Mock;
+  warn: jest.Mock;
+  info: jest.Mock;
+  debug: jest.Mock;
+} => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
 
 describe('toHandlerResult', () => {
-  it('maps AlertManagerError not_found to 404', () => {
-    const result = toHandlerResult(createNotFoundError('gone'));
-    expect(result).toEqual({ status: 404, body: { error: 'gone' } });
+  it('maps AlertManagerError not_found to 404 and passes the typed message through', () => {
+    const result = toHandlerResult(createNotFoundError('Monitor gone'));
+    expect(result).toEqual({ status: 404, body: { error: 'Monitor gone' } });
   });
 
-  it('maps AlertManagerError validation to 400', () => {
+  it('maps AlertManagerError validation to 400 and passes the typed message through', () => {
     const result = toHandlerResult(createValidationError('bad'));
     expect(result).toEqual({ status: 400, body: { error: 'bad' } });
   });
 
-  it('maps AlertManagerError internal to 500 with generic message', () => {
-    const result = toHandlerResult(createInternalError('secret'));
+  it('maps AlertManagerError internal to 500 with a generic message (hides internal detail)', () => {
+    const result = toHandlerResult(createInternalError('secret detail'));
     expect(result).toEqual({ status: 500, body: { error: 'An internal error occurred' } });
+  });
+
+  it('maps AlertManagerError conflict to 409', () => {
+    const result = toHandlerResult(createConflictError('Concurrent writer'));
+    expect(result).toEqual({ status: 409, body: { error: 'Concurrent writer' } });
   });
 
   it('handles null/undefined', () => {
@@ -31,15 +50,41 @@ describe('toHandlerResult', () => {
     expect(toHandlerResult(undefined).status).toBe(500);
   });
 
-  it('classifies plain Error with "not found" as 404', () => {
-    expect(toHandlerResult(new Error('Resource not found')).status).toBe(404);
+  it('classifies plain Error with "not found" as 404 and scrubs the original message', () => {
+    const logger = makeLogger();
+    const result = toHandlerResult(
+      new Error('monitor not found in index [monitors] on cluster-prod-01.internal'),
+      logger
+    );
+    expect(result.status).toBe(404);
+    // Original upstream message must NOT be reflected (would leak index + hostname).
+    expect(result.body).toEqual({ error: 'Resource not found' });
+    // Full upstream message is logged server-side.
+    expect(logger.error).toHaveBeenCalledWith(
+      'monitor not found in index [monitors] on cluster-prod-01.internal'
+    );
   });
 
-  it('classifies plain Error with "validation" as 400', () => {
-    expect(toHandlerResult(new Error('validation failed')).status).toBe(400);
+  it('classifies plain Error with "validation" as 400 and scrubs the message', () => {
+    const logger = makeLogger();
+    const result = toHandlerResult(
+      new Error('validation failed: field foo must be string'),
+      logger
+    );
+    expect(result.status).toBe(400);
+    expect(result.body).toEqual({ error: 'Validation failed' });
+    expect(logger.error).toHaveBeenCalled();
   });
 
-  it('falls back to 500 for unknown errors', () => {
-    expect(toHandlerResult(new Error('something broke')).status).toBe(500);
+  it('falls back to 500 with generic message for unknown errors and never reflects upstream content', () => {
+    const logger = makeLogger();
+    const result = toHandlerResult(
+      new Error('connect ECONNREFUSED cluster-prod-01.internal:9200'),
+      logger
+    );
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({ error: 'An internal error occurred' });
+    expect(JSON.stringify(result.body)).not.toContain('cluster-prod-01.internal');
+    expect(logger.error).toHaveBeenCalledWith('connect ECONNREFUSED cluster-prod-01.internal:9200');
   });
 });

--- a/server/routes/alerting/__tests__/route_utils.test.ts
+++ b/server/routes/alerting/__tests__/route_utils.test.ts
@@ -35,6 +35,14 @@ describe('toHandlerResult', () => {
     expect(result).toEqual({ status: 400, body: { error: 'bad' } });
   });
 
+  it('includes the optional `field` on validation errors so clients can highlight it', () => {
+    const result = toHandlerResult(createValidationError('must be a string', 'monitor.name'));
+    expect(result).toEqual({
+      status: 400,
+      body: { error: 'must be a string', field: 'monitor.name' },
+    });
+  });
+
   it('maps AlertManagerError internal to 500 with a generic message (hides internal detail)', () => {
     const result = toHandlerResult(createInternalError('secret detail'));
     expect(result).toEqual({ status: 500, body: { error: 'An internal error occurred' } });
@@ -74,6 +82,11 @@ describe('toHandlerResult', () => {
     expect(result.status).toBe(400);
     expect(result.body).toEqual({ error: 'Validation failed' });
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('classifies plain Error with "REQUIRED" or "Must Be" (case-insensitive) as 400', () => {
+    expect(toHandlerResult(new Error('field X is REQUIRED')).status).toBe(400);
+    expect(toHandlerResult(new Error('field X Must Be a string')).status).toBe(400);
   });
 
   it('falls back to 500 with generic message for unknown errors and never reflects upstream content', () => {

--- a/server/routes/alerting/alertmanager_handlers.ts
+++ b/server/routes/alerting/alertmanager_handlers.ts
@@ -12,10 +12,20 @@ import type {
   AlertingOSClient,
   AlertmanagerSilence,
   Datasource,
+  Logger,
   PrometheusBackend,
 } from '../../../common/types/alerting';
+import { isStatusCode } from '../../services/alerting';
 import { toHandlerResult } from './route_utils';
 import type { HandlerResult } from './route_utils';
+
+/**
+ * Discriminates the body shape of the Alertmanager config route so the UI
+ * can distinguish "not configured" from "unauthorized" from a real upstream
+ * failure. Before, every failure was reflected as `{ available: false }`
+ * with HTTP 200, which masked authz denials as config state.
+ */
+type AlertmanagerConfigCode = 'ok' | 'not_configured' | 'unauthorized' | 'upstream_error';
 
 // ============================================================================
 // Alertmanager API v2 Handlers
@@ -195,11 +205,24 @@ export function extractReceiverIntegrations(
 export async function handleGetAlertmanagerConfig(
   promBackend: PrometheusBackend,
   client: AlertingOSClient,
-  ds: Datasource
+  ds: Datasource,
+  logger?: Logger
 ): Promise<HandlerResult> {
+  const codeNotConfigured: AlertmanagerConfigCode = 'not_configured';
+  const codeUnauthorized: AlertmanagerConfigCode = 'unauthorized';
+  const codeUpstreamError: AlertmanagerConfigCode = 'upstream_error';
+  const codeOk: AlertmanagerConfigCode = 'ok';
+
   try {
     if (!promBackend.getAlertmanagerStatus) {
-      return { status: 200, body: { available: false, error: 'Alertmanager not configured' } };
+      return {
+        status: 200,
+        body: {
+          available: false,
+          code: codeNotConfigured,
+          error: 'Alertmanager not configured',
+        },
+      };
     }
     const status = await promBackend.getAlertmanagerStatus(client, ds);
     const rawYaml = status.config?.original || '';
@@ -237,6 +260,7 @@ export async function handleGetAlertmanagerConfig(
       status: 200,
       body: {
         available: true,
+        code: codeOk,
         cluster: {
           status: status.cluster?.status || 'unknown',
           peers: status.cluster?.peers || [],
@@ -250,11 +274,28 @@ export async function handleGetAlertmanagerConfig(
       },
     };
   } catch (e: unknown) {
+    // Log the full upstream error server-side; never reflect its `message`
+    // to the browser (may contain cluster URLs / stack fragments / index names).
+    if (logger) logger.error(e instanceof Error ? e.message : String(e));
+
+    if (isStatusCode(e, 401) || isStatusCode(e, 403)) {
+      const upstreamStatus = isStatusCode(e, 401) ? 401 : 403;
+      return {
+        status: upstreamStatus,
+        body: {
+          available: false,
+          code: codeUnauthorized,
+          error: upstreamStatus === 401 ? 'Unauthorized' : 'Forbidden',
+        },
+      };
+    }
+
     return {
-      status: 200,
+      status: 500,
       body: {
         available: false,
-        error: e instanceof Error ? e.message : 'Failed to fetch Alertmanager config',
+        code: codeUpstreamError,
+        error: 'Failed to fetch Alertmanager config',
       },
     };
   }

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -6,27 +6,26 @@
 /**
  * OSD route adapter — wires framework-agnostic handlers to OSD's IRouter.
  *
- * Phase 5 state:
- *   - 14 inline routes (reads: unified/alerts, unified/rules, OS monitor reads,
- *     OS alert reads, Prom rules, Prom alerts, rule/alert detail, AM config,
- *     4 Prom metadata).
- *   - 4 mutation routes moved to `./mutations/` (registered via
- *     `registerAlertingMutationRoutes` below).
- *   - Datasource CRUD routes deleted in Phase 3 (client reads from
- *     `data-source` / `data-connection` saved-object types directly).
- *   - `InMemoryDatasourceService` deleted; MDS client routing and Prometheus
- *     datasource lookup happen via `resolveOpenSearchDatasource` /
- *     `resolvePrometheusDatasource` saved-object helpers below.
- *   - Feature-flag gated at the call site (`setupRoutes` in
- *     `server/routes/index.ts`) via `if (alertManagerEnabled)`.
+ * Concurrency model: stateless backends (`HttpOpenSearchBackend`,
+ * `DirectQueryPrometheusBackend`, `MonitorMutationService`) are constructed
+ * once by `setupRoutes` and passed in. Stateful services that hold a
+ * `SavedObjectDatasourceService` — namely `MultiBackendAlertService` and
+ * `PrometheusMetadataService` — are constructed **per request** inside
+ * `buildRequestServices(ctx)` so they carry only the scoped SavedObjects
+ * client for that request. No singleton is ever mutated mid-request; no
+ * per-tenant data can leak between concurrent callers.
  */
 import { schema } from '@osd/config-schema';
 import { IRouter, RequestHandlerContext, SavedObject } from '../../../../../src/core/server';
 import type { AlertingOSClient, Datasource, Logger } from '../../../common/types/alerting';
-import { MultiBackendAlertService } from '../../services/alerting';
+import {
+  HttpOpenSearchBackend,
+  MultiBackendAlertService,
+  PrometheusMetadataService,
+  SavedObjectDatasourceService,
+} from '../../services/alerting';
 import { DirectQueryPrometheusBackend } from '../../services/alerting/directquery_prometheus_backend';
 import { MonitorMutationService } from '../../services/alerting/monitor_mutation_service';
-import { SavedObjectDatasourceService } from '../../services/alerting/saved_object_datasource_service';
 import { registerAlertingMutationRoutes } from './mutations';
 import { toErrorBody } from './route_utils';
 
@@ -70,17 +69,29 @@ import {
   handleGetLabelValues,
   handleGetMetricMetadata,
 } from './metadata_handlers';
-import { PrometheusMetadataService } from '../../services/alerting/prometheus_metadata_service';
 import { handleGetAlertmanagerConfig } from './alertmanager_handlers';
 
-export function registerAlertingRoutes(
-  router: IRouter,
-  alertService: MultiBackendAlertService,
-  mutationSvc: MonitorMutationService,
-  promBackend: DirectQueryPrometheusBackend,
-  logger?: Logger,
-  metadataService?: PrometheusMetadataService
-) {
+export interface AlertingRoutesDeps {
+  osBackend: HttpOpenSearchBackend;
+  promBackend: DirectQueryPrometheusBackend;
+  mutationSvc: MonitorMutationService;
+  logger?: Logger;
+  /**
+   * Register the 4 Prometheus metadata routes in addition to the core set.
+   * Defaults to true; tests can toggle to cover the reduced registration
+   * surface.
+   */
+  enableMetadataRoutes?: boolean;
+}
+
+export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps) {
+  const { osBackend, promBackend, mutationSvc, enableMetadataRoutes = true } = deps;
+  const logger: Logger = deps.logger ?? {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  };
   /**
    * Resolve an OpenSearch datasource from the `data-source` saved-object type.
    * Returns `null` for an unknown id. If `requestedDsId` is undefined, returns
@@ -186,20 +197,31 @@ export function registerAlertingRoutes(
   }
 
   /**
-   * Bind a per-request `SavedObjectDatasourceService` to the shared alert
-   * service + metadata service. Must be called at the start of every route
-   * handler that invokes methods on either service (they internally call
-   * `this.datasourceService.get(...)` / `list()`). The services otherwise
-   * share a bootstrap adapter from `setupRoutes` that has no saved-objects
-   * client.
+   * Construct the per-request stateful alerting services bound to this
+   * request's scoped SavedObjects client. Replaces the pre-Phase-5 mutable
+   * `setDatasourceService` singleton pattern, which leaked SavedObjects
+   * clients across concurrent requests at every `await` boundary.
+   *
+   * Call at the top of every handler; the returned `alertService` /
+   * `metadataService` instances are short-lived and die when the handler
+   * returns.
    */
-  function bindRequestDatasources(ctx: AlertingHandlerContext): SavedObjectDatasourceService {
-    const ds = new SavedObjectDatasourceService(ctx.core.savedObjects.client, logger);
-    alertService.setDatasourceService(ds);
-    if (metadataService) {
-      metadataService.setDatasourceService(ds);
-    }
-    return ds;
+  function buildRequestServices(
+    ctx: AlertingHandlerContext
+  ): {
+    alertService: MultiBackendAlertService;
+    metadataService: PrometheusMetadataService;
+    datasourceService: SavedObjectDatasourceService;
+  } {
+    const datasourceService = new SavedObjectDatasourceService(
+      ctx.core.savedObjects.client,
+      logger
+    );
+    const alertService = new MultiBackendAlertService(datasourceService, logger);
+    alertService.registerOpenSearch(osBackend);
+    alertService.registerPrometheus(promBackend);
+    const metadataService = new PrometheusMetadataService(promBackend, datasourceService, logger);
+    return { alertService, metadataService, datasourceService };
   }
 
   // Mutation routes (create/update/delete monitor + acknowledge alert) live
@@ -222,7 +244,7 @@ export function registerAlertingRoutes(
       },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetUnifiedAlerts(
         alertService,
         async (dsId: string) => getAlertingClient(ctx, dsId),
@@ -248,7 +270,7 @@ export function registerAlertingRoutes(
       },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetUnifiedRules(
         alertService,
         async (dsId: string) => getAlertingClient(ctx, dsId),
@@ -269,7 +291,7 @@ export function registerAlertingRoutes(
       validate: { params: schema.object({ dsId: schema.string() }) },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetOSMonitors(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -287,7 +309,7 @@ export function registerAlertingRoutes(
       validate: { params: schema.object({ dsId: schema.string(), monitorId: schema.string() }) },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetOSMonitor(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -309,7 +331,7 @@ export function registerAlertingRoutes(
       validate: { params: schema.object({ dsId: schema.string() }) },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetOSAlerts(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -330,7 +352,7 @@ export function registerAlertingRoutes(
       validate: { params: schema.object({ dsId: schema.string() }) },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetPromRuleGroups(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -348,7 +370,7 @@ export function registerAlertingRoutes(
       validate: { params: schema.object({ dsId: schema.string() }) },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetPromAlerts(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -369,7 +391,7 @@ export function registerAlertingRoutes(
       },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetRuleDetail(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -390,7 +412,7 @@ export function registerAlertingRoutes(
       },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
+      const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetAlertDetail(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
@@ -413,10 +435,11 @@ export function registerAlertingRoutes(
       validate: { query: schema.object({ dsId: schema.maybe(schema.string()) }) },
     },
     async (ctx, req, res) => {
-      bindRequestDatasources(ctx as AlertingHandlerContext);
       // Alertmanager is reached through a Prometheus datasource. Use the
       // saved-object-backed resolver — saved-object IDs are stable across
-      // server restarts (addresses Comments 8 + 11).
+      // server restarts (addresses Comments 8 + 11). This route doesn't need
+      // a MultiBackendAlertService because it talks directly to promBackend,
+      // so we skip the buildRequestServices allocation.
       const promDs = await resolvePrometheusDatasource(
         ctx as AlertingHandlerContext,
         req.query.dsId
@@ -425,6 +448,7 @@ export function registerAlertingRoutes(
         return res.ok({
           body: {
             available: false,
+            code: 'not_configured',
             error: req.query.dsId
               ? `Prometheus datasource "${req.query.dsId}" not found.`
               : 'No Prometheus datasource configured. Add a Prometheus direct-query connection.',
@@ -434,9 +458,17 @@ export function registerAlertingRoutes(
       const result = await handleGetAlertmanagerConfig(
         promBackend,
         await getAlertingClient(ctx as AlertingHandlerContext),
-        promDs
+        promDs,
+        logger
       );
-      return res.ok({ body: result.body });
+      if (result.status === 200) return res.ok({ body: result.body });
+      if (result.status === 401) {
+        return res.unauthorized({ body: result.body });
+      }
+      if (result.status === 403) {
+        return res.forbidden({ body: result.body });
+      }
+      return res.customError({ statusCode: result.status, body: result.body });
     }
   );
 
@@ -444,7 +476,7 @@ export function registerAlertingRoutes(
   // Prometheus Metadata Routes
   // ===========================================================================
 
-  if (metadataService) {
+  if (enableMetadataRoutes) {
     router.get(
       {
         path: '/api/alerting/prometheus/{dsId}/metadata/metrics',
@@ -454,7 +486,7 @@ export function registerAlertingRoutes(
         },
       },
       async (ctx, req, res) => {
-        bindRequestDatasources(ctx as AlertingHandlerContext);
+        const { metadataService } = buildRequestServices(ctx as AlertingHandlerContext);
         const result = await handleGetMetricNames(
           metadataService,
           await getAlertingClient(ctx, req.params.dsId),
@@ -475,7 +507,7 @@ export function registerAlertingRoutes(
         },
       },
       async (ctx, req, res) => {
-        bindRequestDatasources(ctx as AlertingHandlerContext);
+        const { metadataService } = buildRequestServices(ctx as AlertingHandlerContext);
         const result = await handleGetLabelNames(
           metadataService,
           await getAlertingClient(ctx, req.params.dsId),
@@ -496,7 +528,7 @@ export function registerAlertingRoutes(
         },
       },
       async (ctx, req, res) => {
-        bindRequestDatasources(ctx as AlertingHandlerContext);
+        const { metadataService } = buildRequestServices(ctx as AlertingHandlerContext);
         const result = await handleGetLabelValues(
           metadataService,
           await getAlertingClient(ctx, req.params.dsId),
@@ -517,7 +549,7 @@ export function registerAlertingRoutes(
         },
       },
       async (ctx, req, res) => {
-        bindRequestDatasources(ctx as AlertingHandlerContext);
+        const { metadataService } = buildRequestServices(ctx as AlertingHandlerContext);
         const result = await handleGetMetricMetadata(
           metadataService,
           await getAlertingClient(ctx, req.params.dsId),

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -224,6 +224,21 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     return { alertService, metadataService, datasourceService };
   }
 
+  /**
+   * Map a framework-agnostic `HandlerResult` to the right OSD response. The
+   * happy path (or explicit `okStatus`, e.g. 201 for create) emits `res.ok`
+   * with the raw body; anything else routes through `toErrorBody` so the
+   * wire shape stays consistent, and the original status carries through via
+   * `res.customError`. Replaces per-route ternaries that used to flatten
+   * everything to `res.badRequest` / `res.notFound`, which defeated the
+   * status-preserving work in `toHandlerResult`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function sendResult(res: any, result: { status: number; body: any }, okStatus: number = 200) {
+    if (result.status === okStatus) return res.ok({ body: result.body });
+    return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
+  }
+
   // Mutation routes (create/update/delete monitor + acknowledge alert) live
   // in `./mutations/` — register them via the dedicated registrar so the split
   // stays clean.
@@ -297,9 +312,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         await getAlertingClient(ctx, req.params.dsId),
         req.params.dsId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.badRequest({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
 
@@ -316,9 +329,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         req.params.dsId,
         req.params.monitorId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.notFound({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
   // OS monitor mutations (POST create, PUT update, DELETE delete) moved to
@@ -337,9 +348,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         await getAlertingClient(ctx, req.params.dsId),
         req.params.dsId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.badRequest({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
 
@@ -358,9 +367,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         await getAlertingClient(ctx, req.params.dsId),
         req.params.dsId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.badRequest({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
 
@@ -376,9 +383,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         await getAlertingClient(ctx, req.params.dsId),
         req.params.dsId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.badRequest({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
 
@@ -398,9 +403,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         req.params.dsId,
         req.params.ruleId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.notFound({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
 
@@ -419,9 +422,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         req.params.dsId,
         req.params.alertId
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.notFound({ body: toErrorBody(result.body) });
+      return sendResult(res, result);
     }
   );
 
@@ -461,6 +462,13 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         promDs,
         logger
       );
+      // This route intentionally returns a domain envelope
+      // `{ available, code, ... }` on BOTH success and error paths — the UI
+      // treats `code` as the discriminator and `available` as the boolean.
+      // Do NOT funnel error bodies through `toErrorBody` here; that would
+      // collapse the envelope into OSD's `{ message, attributes }` shape and
+      // break the UI's consumer. Do preserve the upstream HTTP status code
+      // so auth failures show as 401/403 rather than masked as 200.
       if (result.status === 200) return res.ok({ body: result.body });
       if (result.status === 401) {
         return res.unauthorized({ body: result.body });

--- a/server/routes/alerting/mutations/index.ts
+++ b/server/routes/alerting/mutations/index.ts
@@ -154,9 +154,12 @@ export function registerAlertingMutationRoutes(
         // OSD schema validates loosely; narrow to the typed domain shape
         (req.body as unknown) as Partial<OSMonitor>
       );
-      return result.status === 200
-        ? res.ok({ body: result.body })
-        : res.notFound({ body: toErrorBody(result.body) });
+      if (result.status === 200) return res.ok({ body: result.body });
+      if (result.status === 404) return res.notFound({ body: toErrorBody(result.body) });
+      if (result.status === 409) {
+        return res.conflict({ body: toErrorBody(result.body) });
+      }
+      return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
     }
   );
 
@@ -170,9 +173,9 @@ export function registerAlertingMutationRoutes(
       try {
         const client = await getClient(ctx, req.params.dsId);
         const result = await handleDeleteOSMonitor(mutationSvc, client, req.params.monitorId);
-        return result.status === 200
-          ? res.ok({ body: result.body })
-          : res.notFound({ body: toErrorBody(result.body) });
+        if (result.status === 200) return res.ok({ body: result.body });
+        if (result.status === 404) return res.notFound({ body: toErrorBody(result.body) });
+        return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
       } catch (_e) {
         return res.badRequest({ body: { message: `Invalid datasource: ${req.params.dsId}` } });
       }

--- a/server/routes/alerting/mutations/index.ts
+++ b/server/routes/alerting/mutations/index.ts
@@ -133,7 +133,11 @@ export function registerAlertingMutationRoutes(
         // OSD schema validates loosely; narrow to the typed domain shape
         (req.body as unknown) as Omit<OSMonitor, 'id'>
       );
-      return res.ok({ body: result.body });
+      // Create success is 201; anything else is an error classified by
+      // `toHandlerResult`. Previously this unconditionally called res.ok,
+      // masking failures as HTTP 200 with an error body.
+      if (result.status === 201) return res.ok({ body: result.body });
+      return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
     }
   );
 
@@ -198,7 +202,8 @@ export function registerAlertingMutationRoutes(
         req.params.monitorId,
         req.body
       );
-      return res.ok({ body: result.body });
+      if (result.status === 200) return res.ok({ body: result.body });
+      return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
     }
   );
 }

--- a/server/routes/alerting/route_utils.ts
+++ b/server/routes/alerting/route_utils.ts
@@ -24,8 +24,13 @@ export interface HandlerResult {
 export function toHandlerResult(e: unknown, logger?: Logger): HandlerResult {
   if (isAlertManagerError(e)) {
     if (logger) logger.error(e.message);
-    const body =
-      e.kind === 'internal' ? { error: 'An internal error occurred' } : { error: e.message };
+    if (e.kind === 'internal') {
+      return { status: 500, body: { error: 'An internal error occurred' } };
+    }
+    // Typed errors carry intentionally-UI-safe messages. Surface the optional
+    // `field` on validation errors so clients can do per-field highlights.
+    const body: Record<string, unknown> = { error: e.message };
+    if (e.kind === 'validation' && e.field) body.field = e.field;
     return { status: errorToStatus(e), body };
   }
   // Guard against null/undefined being thrown — String(null) → "null" is unhelpful
@@ -35,13 +40,14 @@ export function toHandlerResult(e: unknown, logger?: Logger): HandlerResult {
   }
   const msg = e instanceof Error ? e.message : String(e);
   if (logger) logger.error(msg);
-  if (msg.toLowerCase().includes('not found')) {
+  const lowerMsg = msg.toLowerCase();
+  if (lowerMsg.includes('not found')) {
     return { status: 404, body: { error: 'Resource not found' } };
   }
   if (
-    msg.toLowerCase().includes('validation') ||
-    msg.includes('required') ||
-    msg.includes('must be')
+    lowerMsg.includes('validation') ||
+    lowerMsg.includes('required') ||
+    lowerMsg.includes('must be')
   ) {
     return { status: 400, body: { error: 'Validation failed' } };
   }

--- a/server/routes/alerting/route_utils.ts
+++ b/server/routes/alerting/route_utils.ts
@@ -13,8 +13,13 @@ export interface HandlerResult {
 
 /**
  * Convert any caught error into a framework-agnostic handler result.
- * Uses the typed error system (AlertManagerError) when available,
- * falls back to message-based classification for legacy errors.
+ *
+ * Only typed `AlertManagerError` messages are surfaced to clients — those are
+ * intentionally shaped for UI display (e.g. "Monitor not found"). Generic
+ * `Error.message` content is **never** reflected back, since upstream
+ * OpenSearch / Prometheus exceptions routinely include cluster URLs, index
+ * names, or stack fragments that leak internal topology. The full upstream
+ * message is always logged server-side when a `logger` is supplied.
  */
 export function toHandlerResult(e: unknown, logger?: Logger): HandlerResult {
   if (isAlertManagerError(e)) {
@@ -31,14 +36,14 @@ export function toHandlerResult(e: unknown, logger?: Logger): HandlerResult {
   const msg = e instanceof Error ? e.message : String(e);
   if (logger) logger.error(msg);
   if (msg.toLowerCase().includes('not found')) {
-    return { status: 404, body: { error: msg } };
+    return { status: 404, body: { error: 'Resource not found' } };
   }
   if (
     msg.toLowerCase().includes('validation') ||
     msg.includes('required') ||
     msg.includes('must be')
   ) {
-    return { status: 400, body: { error: msg } };
+    return { status: 400, body: { error: 'Validation failed' } };
   }
   return { status: 500, body: { error: 'An internal error occurred' } };
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -30,11 +30,8 @@ import { registerTraceAnalyticsDslRouter } from './trace_analytics_dsl_router';
 import { registerAlertingRoutes } from './alerting';
 import {
   HttpOpenSearchBackend,
-  MultiBackendAlertService,
   MonitorMutationService,
   DirectQueryPrometheusBackend,
-  PrometheusMetadataService,
-  SavedObjectDatasourceService,
 } from '../services/alerting';
 
 export function setupRoutes({
@@ -85,29 +82,21 @@ export function setupRoutes({
   // flag is off the routes are never registered, so curl returns 404 for
   // both mutations and the AM config endpoint.
   if (alertManagerEnabled) {
-    // Construct a placeholder adapter that will be swapped per-request by the
-    // route layer via `service.setDatasourceService(...)`. The placeholder is
-    // fine because no method is invoked at registration time — every code
-    // path that reads `this.datasourceService` flows through a request handler
-    // which will have swapped in a live adapter first.
-    const bootstrapDatasources = new SavedObjectDatasourceService(
-      // Cast is safe: the bootstrap adapter is never read (see note above).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (null as unknown) as any,
-      logger
-    );
-
+    // Only construct the genuinely stateless deps at server start. The
+    // per-request `MultiBackendAlertService` and `PrometheusMetadataService`
+    // instances — both of which hold a `SavedObjectDatasourceService` — are
+    // built inside each route handler so the per-request scoped SavedObjects
+    // client never bleeds across concurrent requests.
     const osBackend = new HttpOpenSearchBackend(logger);
     const promBackend = new DirectQueryPrometheusBackend(logger);
-
-    const alertSvc = new MultiBackendAlertService(bootstrapDatasources, logger);
-    alertSvc.registerOpenSearch(osBackend);
-    alertSvc.registerPrometheus(promBackend);
-
-    const metadataSvc = new PrometheusMetadataService(promBackend, bootstrapDatasources, logger);
-
     const mutationSvc = new MonitorMutationService(logger);
 
-    registerAlertingRoutes(router, alertSvc, mutationSvc, promBackend, logger, metadataSvc);
+    registerAlertingRoutes(router, {
+      osBackend,
+      promBackend,
+      mutationSvc,
+      logger,
+      enableMetadataRoutes: true,
+    });
   }
 }

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -158,4 +158,63 @@ describe('MultiBackendAlertService — routing & list', () => {
     const response = await svc.getUnifiedAlerts(resolver);
     expect(response.totalDatasources).toBe(1);
   });
+
+  // ---- concurrency isolation ----
+  /**
+   * Guards against the regressed "shared singleton + setDatasourceService"
+   * pattern that leaked SavedObjects clients across concurrent requests.
+   * The service no longer exposes a setter — the datasourceService is set
+   * exclusively via the constructor, so two concurrently-constructed
+   * instances cannot see each other's datasources even when their handlers
+   * yield at the same `await` boundary.
+   */
+  it('separate instances cannot observe each other’s datasources under concurrent awaits', async () => {
+    const dsA: Datasource = { id: 'ds-a', name: 'A', type: 'opensearch', url: '', enabled: true };
+    const dsB: Datasource = { id: 'ds-b', name: 'B', type: 'opensearch', url: '', enabled: true };
+
+    const makeDsSvc = (list: Datasource[]) => ({
+      list: jest.fn(async () => list),
+      get: jest.fn(async (id: string) => list.find((d) => d.id === id) ?? null),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      testConnection: jest.fn(),
+      seed: jest.fn(),
+    });
+
+    const osBackend = {
+      getMonitors: jest.fn(async () => []),
+      getMonitor: jest.fn(),
+      createMonitor: jest.fn(),
+      updateMonitor: jest.fn(),
+      deleteMonitor: jest.fn(),
+      getAlerts: jest.fn(async () => ({ alerts: [], totalAlerts: 0 })),
+      acknowledgeAlerts: jest.fn(),
+      getDestinations: jest.fn(async () => []),
+      searchQuery: jest.fn(),
+    };
+
+    const dsSvcA = makeDsSvc([dsA]);
+    const dsSvcB = makeDsSvc([dsB]);
+
+    const svcA = new MultiBackendAlertService(dsSvcA, mockLogger);
+    svcA.registerOpenSearch(osBackend as never);
+    const svcB = new MultiBackendAlertService(dsSvcB, mockLogger);
+    svcB.registerOpenSearch(osBackend as never);
+
+    // Interleave: kick off A, then B; each resolves against its own ds list.
+    const resolver = jest.fn(async () => ({} as never));
+    const [respA, respB] = await Promise.all([
+      svcA.getUnifiedAlerts(resolver),
+      svcB.getUnifiedAlerts(resolver),
+    ]);
+
+    expect(respA.totalDatasources).toBe(1);
+    expect(respB.totalDatasources).toBe(1);
+    expect(dsSvcA.list).toHaveBeenCalled();
+    expect(dsSvcB.list).toHaveBeenCalled();
+    // Request A must never have reached into request B's datasource service.
+    await expect(dsSvcA.list.mock.results[0].value).resolves.toEqual([dsA]);
+    await expect(dsSvcB.list.mock.results[0].value).resolves.toEqual([dsB]);
+  });
 });

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -163,11 +163,40 @@ describe('MultiBackendAlertService — routing & list', () => {
   /**
    * Guards against the regressed "shared singleton + setDatasourceService"
    * pattern that leaked SavedObjects clients across concurrent requests.
-   * The service no longer exposes a setter — the datasourceService is set
-   * exclusively via the constructor, so two concurrently-constructed
-   * instances cannot see each other's datasources even when their handlers
-   * yield at the same `await` boundary.
+   *
+   * **What this test proves:** two freshly-constructed `MultiBackendAlertService`
+   * instances, when driven concurrently via `Promise.all`, each resolve
+   * datasources from their own `datasourceService` mock and never cross over.
+   *
+   * **What this test does NOT prove (acknowledged limitation):** because
+   * `datasourceService` is stored in a `private readonly` field, this is
+   * true by construction — the test would pass even if `setDatasourceService`
+   * were still present and the route layer shared a single instance, as long
+   * as callers constructed fresh services themselves. The second assertion
+   * (the `@ts-expect-error` below) is therefore the real regression guard:
+   * it will fail to compile if someone re-introduces the setter.
    */
+  it('has no setDatasourceService setter — the regression guard', () => {
+    const dsSvc = {
+      list: jest.fn(async () => []),
+      get: jest.fn(async () => null),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      testConnection: jest.fn(),
+      seed: jest.fn(),
+    };
+    const instance = new MultiBackendAlertService(dsSvc, mockLogger);
+    // Compile-time assertion: `setDatasourceService` must not exist on the
+    // type. Re-adding it resurrects the cross-tenant SavedObjects-client
+    // leak. The `@ts-expect-error` below will fail to compile if the setter
+    // comes back, catching the regression at tsc time (well before any
+    // runtime test could).
+    // @ts-expect-error setDatasourceService was intentionally removed
+    const setter = instance.setDatasourceService;
+    expect(setter).toBeUndefined();
+  });
+
   it('separate instances cannot observe each other’s datasources under concurrent awaits', async () => {
     const dsA: Datasource = { id: 'ds-a', name: 'A', type: 'opensearch', url: '', enabled: true };
     const dsB: Datasource = { id: 'ds-b', name: 'B', type: 'opensearch', url: '', enabled: true };

--- a/server/services/alerting/__tests__/errors.test.ts
+++ b/server/services/alerting/__tests__/errors.test.ts
@@ -56,6 +56,14 @@ describe('errors', () => {
       expect(isStatusCode(Object.assign(new Error('boom'), { statusCode: 409 }), 409)).toBe(true);
     });
 
+    it('falls back to meta.statusCode', () => {
+      expect(isStatusCode({ meta: { statusCode: 403 } }, 403)).toBe(true);
+    });
+
+    it('falls back to body.status (DirectQuery-wrapped upstream error)', () => {
+      expect(isStatusCode({ body: { status: 401 } }, 401)).toBe(true);
+    });
+
     it('returns false for non-matching or missing statusCode', () => {
       expect(isStatusCode({ statusCode: 500 }, 404)).toBe(false);
       expect(isStatusCode(new Error('HTTP 404 not found'), 404)).toBe(false);

--- a/server/services/alerting/__tests__/errors.test.ts
+++ b/server/services/alerting/__tests__/errors.test.ts
@@ -7,7 +7,9 @@ import {
   createNotFoundError,
   createValidationError,
   createInternalError,
+  createConflictError,
   isAlertManagerError,
+  isStatusCode,
   errorToStatus,
 } from '../errors';
 
@@ -26,8 +28,17 @@ describe('errors', () => {
     expect(createInternalError('boom')).toEqual({ kind: 'internal', message: 'boom' });
   });
 
+  it('createConflictError returns correct shape', () => {
+    expect(createConflictError('stale', 'id-2')).toEqual({
+      kind: 'conflict',
+      message: 'stale',
+      resourceId: 'id-2',
+    });
+  });
+
   it('isAlertManagerError validates correctly', () => {
     expect(isAlertManagerError(createNotFoundError('x'))).toBe(true);
+    expect(isAlertManagerError(createConflictError('x'))).toBe(true);
     expect(isAlertManagerError({ kind: 'unknown', message: 'x' })).toBe(false);
     expect(isAlertManagerError(null)).toBe(false);
   });
@@ -36,5 +47,21 @@ describe('errors', () => {
     expect(errorToStatus(createNotFoundError('x'))).toBe(404);
     expect(errorToStatus(createValidationError('x'))).toBe(400);
     expect(errorToStatus(createInternalError('x'))).toBe(500);
+    expect(errorToStatus(createConflictError('x'))).toBe(409);
+  });
+
+  describe('isStatusCode', () => {
+    it('returns true when the value carries a matching numeric statusCode', () => {
+      expect(isStatusCode({ statusCode: 404 }, 404)).toBe(true);
+      expect(isStatusCode(Object.assign(new Error('boom'), { statusCode: 409 }), 409)).toBe(true);
+    });
+
+    it('returns false for non-matching or missing statusCode', () => {
+      expect(isStatusCode({ statusCode: 500 }, 404)).toBe(false);
+      expect(isStatusCode(new Error('HTTP 404 not found'), 404)).toBe(false);
+      expect(isStatusCode(null, 404)).toBe(false);
+      expect(isStatusCode(undefined, 404)).toBe(false);
+      expect(isStatusCode('404', 404)).toBe(false);
+    });
   });
 });

--- a/server/services/alerting/__tests__/monitor_mutation_service.test.ts
+++ b/server/services/alerting/__tests__/monitor_mutation_service.test.ts
@@ -12,6 +12,10 @@
 
 import type { AlertingOSClient, Logger, OSMonitor } from '../../../../common/types/alerting';
 import { MonitorMutationService } from '../monitor_mutation_service';
+import { isAlertManagerError } from '../errors';
+
+const err = (message: string, statusCode: number): Error =>
+  Object.assign(new Error(message), { statusCode });
 
 const mockLogger: Logger = {
   info: jest.fn(),
@@ -109,14 +113,52 @@ describe('MonitorMutationService', () => {
       );
     });
 
-    it('returns null when the monitor does not exist', async () => {
-      const { client } = makeClient([new Error('HTTP 404')]);
+    it('returns null when the monitor does not exist (404 on GET)', async () => {
+      const { client } = makeClient([err('not_found_exception', 404)]);
       expect(await svc.updateMonitor(client, 'missing', { name: 'x' })).toBeNull();
     });
 
-    it('rethrows non-404 errors', async () => {
-      const { client } = makeClient([new Error('HTTP 500 server error')]);
-      await expect(svc.updateMonitor(client, 'mon-1', { name: 'x' })).rejects.toThrow('HTTP 500');
+    it('rethrows non-404 errors on the GET', async () => {
+      const { client } = makeClient([err('server error', 500)]);
+      await expect(svc.updateMonitor(client, 'mon-1', { name: 'x' })).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+
+    it('throws a typed internal error when seq_no/primary_term are missing', async () => {
+      // GET succeeds but the response lacks _seq_no and _primary_term — we
+      // must refuse to downgrade to a non-CAS PUT.
+      const { client } = makeClient([{ body: monitorSource('mon-1', 'A') }]);
+      let thrown: unknown;
+      try {
+        await svc.updateMonitor(client, 'mon-1', { name: 'x' });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(isAlertManagerError(thrown)).toBe(true);
+      expect((thrown as { kind: string }).kind).toBe('internal');
+    });
+
+    it('throws a typed conflict error on 409 from the PUT', async () => {
+      const { client } = makeClient([
+        {
+          body: {
+            ...monitorSource('mon-1', 'A'),
+            _seq_no: 1,
+            _primary_term: 1,
+          },
+        },
+        err('version_conflict_engine_exception', 409),
+      ]);
+      let thrown: unknown;
+      try {
+        await svc.updateMonitor(client, 'mon-1', { name: 'x' });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(isAlertManagerError(thrown)).toBe(true);
+      expect((thrown as { kind: string }).kind).toBe('conflict');
+      expect((thrown as { resourceId?: string }).resourceId).toBe('mon-1');
     });
   });
 
@@ -130,13 +172,15 @@ describe('MonitorMutationService', () => {
         body: undefined,
       });
 
-      const b = makeClient([new Error('HTTP 404')]);
+      const b = makeClient([err('not_found', 404)]);
       expect(await svc.deleteMonitor(b.client, 'mon-1')).toBe(false);
     });
 
     it('rethrows non-404 errors', async () => {
-      const { client } = makeClient([new Error('HTTP 500')]);
-      await expect(svc.deleteMonitor(client, 'mon-1')).rejects.toThrow('HTTP 500');
+      const { client } = makeClient([err('server error', 500)]);
+      await expect(svc.deleteMonitor(client, 'mon-1')).rejects.toMatchObject({
+        statusCode: 500,
+      });
     });
   });
 

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -125,14 +125,18 @@ describe('HttpOpenSearchBackend', () => {
       });
     });
 
-    it('returns null when the monitor is missing (HTTP 404)', async () => {
-      const { client } = makeClient([new Error('HTTP 404 not found')]);
+    it('returns null when the monitor is missing (statusCode 404)', async () => {
+      const err = Object.assign(new Error('index_not_found_exception'), { statusCode: 404 });
+      const { client } = makeClient([err]);
       expect(await backend.getMonitor(client, 'missing')).toBeNull();
     });
 
     it('rethrows non-404 errors', async () => {
-      const { client } = makeClient([new Error('HTTP 500 server error')]);
-      await expect(backend.getMonitor(client, 'mon-1')).rejects.toThrow('HTTP 500');
+      const err = Object.assign(new Error('server error'), { statusCode: 500 });
+      const { client } = makeClient([err]);
+      await expect(backend.getMonitor(client, 'mon-1')).rejects.toMatchObject({
+        statusCode: 500,
+      });
     });
   });
 

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -57,18 +57,10 @@ export class MultiBackendAlertService {
   private osBackend?: OpenSearchBackend;
   private promBackend?: PrometheusBackend;
 
-  constructor(private datasourceService: DatasourceService, private readonly logger: Logger) {}
-
-  /**
-   * Swap the datasource service for this request. Used by the OSD route layer
-   * to inject a per-request `SavedObjectDatasourceService` bound to the
-   * request's saved-objects client. The service is otherwise shared across
-   * requests, so this must be called BEFORE invoking any service method that
-   * reads from `this.datasourceService`.
-   */
-  setDatasourceService(datasourceService: DatasourceService): void {
-    this.datasourceService = datasourceService;
-  }
+  constructor(
+    private readonly datasourceService: DatasourceService,
+    private readonly logger: Logger
+  ) {}
 
   registerOpenSearch(backend: OpenSearchBackend): void {
     this.osBackend = backend;

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -64,7 +64,9 @@ export class MultiBackendAlertService {
 
   registerOpenSearch(backend: OpenSearchBackend): void {
     this.osBackend = backend;
-    this.logger.info('Registered OpenSearch alerting backend');
+    // `debug` (not `info`): this service is constructed per-request, so
+    // registration fires on every request. Keep out of default log output.
+    this.logger.debug('Registered OpenSearch alerting backend');
   }
 
   /** Access the Prometheus backend (e.g. for Alertmanager config route). */
@@ -74,7 +76,8 @@ export class MultiBackendAlertService {
 
   registerPrometheus(backend: PrometheusBackend): void {
     this.promBackend = backend;
-    this.logger.info('Registered Prometheus alerting backend');
+    // `debug` (not `info`): see registerOpenSearch.
+    this.logger.debug('Registered Prometheus alerting backend');
   }
 
   // =========================================================================

--- a/server/services/alerting/errors.ts
+++ b/server/services/alerting/errors.ts
@@ -71,16 +71,30 @@ export function isAlertManagerError(value: unknown): value is AlertManagerError 
 
 /**
  * Type-guard a thrown value against a specific numeric statusCode. Replaces
- * brittle `String(err).includes('HTTP 404')` patterns with a structural check
- * that works against both `ResponseError` (opensearch-js) and any other shape
- * carrying a `statusCode` field.
+ * brittle `String(err).includes('HTTP 404')` patterns with a structural check.
+ *
+ * Probes three places where upstream plugins commonly surface the real HTTP
+ * status code:
+ *   1. `err.statusCode`       — opensearch-js `ResponseError` (top-level).
+ *   2. `err.meta.statusCode`  — alternate surface on some wrapped errors.
+ *   3. `err.body.status`      — DirectQuery / SQL plugin sometimes wraps the
+ *                               upstream status inside its own response body.
+ *
+ * Each check is cheap; falling through all three lets the `is404` and
+ * `isStatusCode(e, 401)` call sites keep working even when the originating
+ * plugin rewraps the upstream error.
  */
 export function isStatusCode(value: unknown, statusCode: number): boolean {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as { statusCode?: unknown }).statusCode === statusCode
-  );
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as {
+    statusCode?: unknown;
+    meta?: { statusCode?: unknown };
+    body?: { status?: unknown };
+  };
+  if (v.statusCode === statusCode) return true;
+  if (v.meta?.statusCode === statusCode) return true;
+  if (v.body?.status === statusCode) return true;
+  return false;
 }
 
 /**

--- a/server/services/alerting/errors.ts
+++ b/server/services/alerting/errors.ts
@@ -26,7 +26,18 @@ export interface InternalError {
   readonly message: string;
 }
 
-export type AlertManagerError = NotFoundError | ValidationError | InternalError;
+/**
+ * Raised when an optimistic-concurrency update (PUT/POST with seq_no +
+ * primary_term) fails because another writer bumped the document. Routes
+ * should surface this as HTTP 409 so the caller can retry after re-fetching.
+ */
+export interface ConflictError {
+  readonly kind: 'conflict';
+  readonly message: string;
+  readonly resourceId?: string;
+}
+
+export type AlertManagerError = NotFoundError | ValidationError | InternalError | ConflictError;
 
 export function createNotFoundError(message: string, resourceId?: string): NotFoundError {
   return { kind: 'not_found', message, resourceId };
@@ -40,15 +51,35 @@ export function createInternalError(message: string): InternalError {
   return { kind: 'internal', message };
 }
 
+export function createConflictError(message: string, resourceId?: string): ConflictError {
+  return { kind: 'conflict', message, resourceId };
+}
+
 export function isAlertManagerError(value: unknown): value is AlertManagerError {
   return (
     typeof value === 'object' &&
     value !== null &&
     'kind' in value &&
     typeof (value as AlertManagerError).kind === 'string' &&
-    ['not_found', 'validation', 'internal'].includes((value as AlertManagerError).kind) &&
+    ['not_found', 'validation', 'internal', 'conflict'].includes(
+      (value as AlertManagerError).kind
+    ) &&
     'message' in value &&
     typeof (value as AlertManagerError).message === 'string'
+  );
+}
+
+/**
+ * Type-guard a thrown value against a specific numeric statusCode. Replaces
+ * brittle `String(err).includes('HTTP 404')` patterns with a structural check
+ * that works against both `ResponseError` (opensearch-js) and any other shape
+ * carrying a `statusCode` field.
+ */
+export function isStatusCode(value: unknown, statusCode: number): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { statusCode?: unknown }).statusCode === statusCode
   );
 }
 
@@ -63,6 +94,8 @@ export function errorToStatus(error: AlertManagerError): number {
       return 400;
     case 'internal':
       return 500;
+    case 'conflict':
+      return 409;
     default: {
       const _exhaustive: never = error;
       return 500;

--- a/server/services/alerting/index.ts
+++ b/server/services/alerting/index.ts
@@ -31,11 +31,19 @@ export { DirectQueryPrometheusBackend } from './directquery_prometheus_backend';
 export { PrometheusMetadataService } from './prometheus_metadata_service';
 export { SavedObjectDatasourceService } from './saved_object_datasource_service';
 
-export type { AlertManagerError, NotFoundError, ValidationError, InternalError } from './errors';
+export type {
+  AlertManagerError,
+  NotFoundError,
+  ValidationError,
+  InternalError,
+  ConflictError,
+} from './errors';
 export {
   createNotFoundError,
   createValidationError,
   createInternalError,
+  createConflictError,
   isAlertManagerError,
+  isStatusCode,
   errorToStatus,
 } from './errors';

--- a/server/services/alerting/monitor_mutation_service.ts
+++ b/server/services/alerting/monitor_mutation_service.ts
@@ -33,6 +33,7 @@ import {
   OSRawTrigger,
   OSRawAction,
 } from '../../../common/types/alerting';
+import { createConflictError, createInternalError, isStatusCode } from './errors';
 
 export class MonitorMutationService {
   constructor(private readonly logger: Logger) {}
@@ -66,34 +67,54 @@ export class MonitorMutationService {
     monitorId: string,
     input: Partial<OSMonitor>
   ): Promise<OSMonitor | null> {
-    // Fetch the current monitor with version info for optimistic concurrency
-    let seqNo: number | undefined;
-    let primaryTerm: number | undefined;
+    // Fetch the current monitor with version info for optimistic concurrency.
+    // Splitting the GET and PUT lets us distinguish a missing monitor (return
+    // null) from a conflict on write (throw typed conflict).
+    let getResp: { body: OSGetMonitorResponse };
     try {
-      const getResp = await this.req<OSGetMonitorResponse>(
+      getResp = await this.req<OSGetMonitorResponse>(
         client,
         'GET',
         `/_plugins/_alerting/monitors/${monitorId}`
       );
-      seqNo = getResp.body._seq_no;
-      primaryTerm = getResp.body._primary_term;
-      const current = this.mapMonitor(getResp.body._id, getResp.body.monitor);
-      const { id: _id, ...currentFields } = current;
-      const merged = { ...currentFields, ...input, last_update_time: Date.now() };
+    } catch (err) {
+      if (isStatusCode(err, 404)) return null;
+      throw err;
+    }
 
-      // Use if_seq_no/if_primary_term for optimistic concurrency control
-      let putPath = `/_plugins/_alerting/monitors/${monitorId}`;
-      if (seqNo !== undefined && primaryTerm !== undefined) {
-        putPath += `?if_seq_no=${seqNo}&if_primary_term=${primaryTerm}`;
-      }
+    const seqNo = getResp.body._seq_no;
+    const primaryTerm = getResp.body._primary_term;
+    // Optimistic concurrency control requires both values. If either is
+    // missing, fail hard rather than silently downgrade to a non-CAS write —
+    // that would allow concurrent writers to clobber each other.
+    if (seqNo === undefined || primaryTerm === undefined) {
+      throw createInternalError(
+        'OpenSearch Alerting GET monitor response missing _seq_no or _primary_term; refusing non-CAS update'
+      );
+    }
 
+    const current = this.mapMonitor(getResp.body._id, getResp.body.monitor);
+    const { id: _id, ...currentFields } = current;
+    const merged = { ...currentFields, ...input, last_update_time: Date.now() };
+
+    const putPath =
+      `/_plugins/_alerting/monitors/${monitorId}` +
+      `?if_seq_no=${seqNo}&if_primary_term=${primaryTerm}`;
+
+    try {
       const resp = await this.req<OSCreateMonitorResponse>(client, 'PUT', putPath, {
         ...merged,
         type: 'monitor',
       });
       return this.mapMonitor(resp.body._id, resp.body.monitor);
     } catch (err) {
-      if (this.is404(err)) return null;
+      if (isStatusCode(err, 404)) return null;
+      if (isStatusCode(err, 409)) {
+        throw createConflictError(
+          `Monitor ${monitorId} was modified by another writer; re-fetch and retry`,
+          monitorId
+        );
+      }
       throw err;
     }
   }
@@ -107,7 +128,7 @@ export class MonitorMutationService {
       await this.req(client, 'DELETE', `/_plugins/_alerting/monitors/${monitorId}`);
       return true;
     } catch (err) {
-      if (this.is404(err)) return false;
+      if (isStatusCode(err, 404)) return false;
       throw err;
     }
   }
@@ -202,9 +223,5 @@ export class MonitorMutationService {
         throttle: a.throttle as OSTrigger['actions'][0]['throttle'],
       })),
     };
-  }
-
-  private is404(err: unknown): boolean {
-    return String(err).includes('HTTP 404');
   }
 }

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -27,6 +27,7 @@ import {
   OSDestinationRaw,
   OSDestinationsApiResponse,
 } from '../../../common/types/alerting';
+import { isStatusCode } from './errors';
 
 export class HttpOpenSearchBackend implements OpenSearchBackend {
   readonly type = 'opensearch' as const;
@@ -355,6 +356,6 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
   }
 
   private is404(err: unknown): boolean {
-    return String(err).includes('HTTP 404');
+    return isStatusCode(err, 404);
   }
 }

--- a/server/services/alerting/prometheus_metadata_service.ts
+++ b/server/services/alerting/prometheus_metadata_service.ts
@@ -16,6 +16,14 @@
  *
  * All methods resolve the Datasource from DatasourceService, then delegate to the provider.
  * On error: logs warning, returns empty array, never throws.
+ *
+ * Lifetime: instances are **per-request** (constructed inside the route
+ * handler against a per-request scoped SavedObjects client). That intentionally
+ * dies with the request to avoid cross-tenant cache leaks — the previous
+ * shared-singleton design served cached data primed by another principal
+ * without a permission check. A per-request cache still helps within a
+ * single handler when multiple methods fetch the same resource, and keeps
+ * the API shape intact.
  */
 
 import type {
@@ -43,17 +51,9 @@ export class PrometheusMetadataService {
 
   constructor(
     private readonly provider: PrometheusMetadataProvider,
-    private datasourceService: DatasourceService,
+    private readonly datasourceService: DatasourceService,
     private readonly logger: Logger
   ) {}
-
-  /**
-   * Swap the datasource service for this request. See
-   * `MultiBackendAlertService.setDatasourceService` for rationale.
-   */
-  setDatasourceService(datasourceService: DatasourceService): void {
-    this.datasourceService = datasourceService;
-  }
 
   // --------------------------------------------------------------------------
   // Public API

--- a/server/services/alerting/prometheus_metadata_service.ts
+++ b/server/services/alerting/prometheus_metadata_service.ts
@@ -6,7 +6,7 @@
 /**
  * Caching wrapper for Prometheus metadata discovery APIs.
  *
- * Implements stale-while-revalidate:
+ * Implements stale-while-revalidate on top of an in-memory `Map`:
  *  - Serves cached data immediately if available (even if stale)
  *  - Triggers a background refresh when cache entry is past TTL
  *  - On first request (cache miss), waits for the result
@@ -17,13 +17,20 @@
  * All methods resolve the Datasource from DatasourceService, then delegate to the provider.
  * On error: logs warning, returns empty array, never throws.
  *
- * Lifetime: instances are **per-request** (constructed inside the route
- * handler against a per-request scoped SavedObjects client). That intentionally
- * dies with the request to avoid cross-tenant cache leaks — the previous
- * shared-singleton design served cached data primed by another principal
- * without a permission check. A per-request cache still helps within a
- * single handler when multiple methods fetch the same resource, and keeps
- * the API shape intact.
+ * Lifetime & caveats: instances are **per-request** (constructed inside the
+ * route handler against a per-request scoped SavedObjects client). That's
+ * intentional — the prior shared-singleton design served cached data primed
+ * by another principal without a permission check, leaking across tenants.
+ *
+ * The trade-off is that the SWR branch is unreachable in normal production
+ * traffic: each request starts with an empty `this.cache`, so `cachedFetch`
+ * always takes the miss path. The cache only helps within a single handler
+ * when the same `(dsId, args)` is fetched twice. The SWR code remains in
+ * place for two reasons: (1) the unit tests still exercise it, and (2) it's
+ * ready to re-enable once a cross-tenant-safe shared cache is introduced
+ * (keyed on principal, e.g. `(workspace_id, dsId, args)`), which is a
+ * follow-up. If you're reading this because metadata autocomplete feels
+ * slow, that follow-up is where to start.
  */
 
 import type {


### PR DESCRIPTION
## Summary

Addresses review findings from PR opensearch-project/dashboards-observability#2653. After a 20-round self-audit, the scope has been trimmed to the fixes that actually address real bugs. Speculative fixes (defending code paths that don't exist) were reverted to keep the diff minimal.

## Required fixes (kept)

### Critical

- **Per-request service construction** (concurrency fix) — `server/routes/alerting/index.ts`, `server/services/alerting/alert_service.ts`, `prometheus_metadata_service.ts`, `server/routes/index.ts`
  Previously `MultiBackendAlertService` and `PrometheusMetadataService` were shared singletons whose `datasourceService` field was mutated at every handler entry via `setDatasourceService`. Under concurrent requests, Node's event loop yielding at any `await` yielded cross-tenant `SavedObjects` client leaks. Replaced with a `buildRequestServices(ctx)` helper that constructs fresh instances per request. Removed the setter, the bootstrap `(null as unknown) as any` hack, and the `eslint-disable` on it.

- **Runbook URL XSS + `rel="noopener noreferrer"`** — `public/components/alerting/alert_detail_flyout.tsx`, `shared_constants.ts`
  `<EuiLink href={action.url} target="_blank">` was rendering user-controlled `alert.annotations.runbook_url` verbatim. A `javascript:` URL would execute in OSD's origin on click. Added `sanitizeExternalUrl(url)` helper (http/https protocol allow-list via `new URL()`).

### High

- **Typed `is404` via `isStatusCode`** — `server/services/alerting/errors.ts`, `monitor_mutation_service.ts`, `opensearch_backend.ts`
  `String(err).includes('HTTP 404')` was a brittle no-op against real opensearch-js `ResponseError` objects. Replaced with `isStatusCode(err, 404)`.

- **`updateMonitor` split + 409 handling** — `server/services/alerting/monitor_mutation_service.ts`, `errors.ts`
  Split GET and PUT. Missing `_seq_no` / `_primary_term` throws typed `InternalError`. 409 on PUT throws `ConflictError` → HTTP 409 instead of masked 500.

- **AM config status preservation** — `server/routes/alerting/alertmanager_handlers.ts`, `server/routes/alerting/index.ts`
  Previously returned HTTP 200 on all failures, masking 401/403 as "not configured". Now 401 → 401, 403 → 403, generic → 500.

- **Lazy-load `AlertingHome`** — `public/components/app.tsx`
  Was eagerly imported, pulling alerting bundle into main observability chunk even when flag is off. Switched to `React.lazy` + `Suspense`.

- **`AlertingPromResourcesService` constructor validation + hook short-circuits** — `query_services/alerting_prom_resources_service.ts`, `hooks/use_prometheus_metadata.ts`
  Constructor throws on empty `datasourceId`. `usePrometheusMetadata` short-circuits effects when no datasource selected.

- **Pagination contract alignment** — `public/components/alerting/hooks/use_alerts.ts`, `use_rules.ts`
  Dropped stale `page` / `pageSize` params and `as PaginatedResponse` cast. Server returns `ProgressiveResponse<T>`, not paginated.

- **Read-route status fan-out** — `server/routes/alerting/index.ts`
  7 inline read routes flattened every non-200 to `res.badRequest` / `res.notFound`, defeating `toHandlerResult` sanitization. Added `sendResult(res, result)` helper.

- **Create / acknowledge routes honor handler status** — `server/routes/alerting/mutations/index.ts`
  Both previously called `res.ok` unconditionally, masking failures as HTTP 200.

- **Error message sanitization** — `server/routes/alerting/route_utils.ts`
  Generic `Error.message` no longer reflected to clients (may contain cluster URLs / index names). Typed errors still pass through. Full upstream always logged server-side.

### Medium

- **Log spam fix** — `server/services/alerting/alert_service.ts`
  Demoted `registerOpenSearch` / `registerPrometheus` INFO logs to DEBUG — they now fire on every request.

### Tests

- Runbook-URL XSS cases (javascript: rejected, https: with rel=noopener, no-url case).
- New `alerting_prom_resources_service.test.ts` — 3 constructor-validation cases.
- New `usePrometheusMetadata` idle-state test.
- Mutation service tests updated to `{ statusCode }` error shape + 404/missing-seq/409 cases.
- Compile-time `@ts-expect-error` regression guard on `setDatasourceService`.
- Updated `route_utils.test.ts` + `alertmanager_handlers.test.ts`.
- Rewrote `server/routes/alerting/__tests__/index.test.ts` for new signature.

## Reverted (audit found these were over-engineering)

- `field` propagation in toHandlerResult — no production caller of `createValidationError` with a `field` arg exists.
- Case-insensitive "required"/"must be" matching — classification nit with no functional impact.
- Credentials-stripping in sanitizeExternalUrl — theoretical threat; browsers warn on basic-auth URLs.
- `isStatusCode` fallbacks to `meta.statusCode` / `body.status` — opensearch-js `statusCode` getter already reads these.
- `code` discriminator field on AM responses — not consumed anywhere.
- Tautological concurrency-isolation test — `@ts-expect-error` guard is the real protection.
- Speculative `console.warn` in metadata fetch catch — original `catch {}` with "non-critical" comment was correct.
- Optional `logger?:` in `AlertingRoutesDeps` + noop fallback — setup always provides a logger.
- Explicit `enableMetadataRoutes: true` at caller — redundant with default.

## Deferred follow-ups (flagged during review, not in this PR)

Real issues identified but out of scope for a focused "fix review findings" PR:

**Server:**
- Unbounded schema string lengths on `dsId`/`ruleId`/`alertId`/`selector` (DoS surface).
- Nested `unknowns: 'ignore'` on monitorBodySchema (unknown-key smuggling).
- `saved_object_datasource_service.ts` broad catch (masks permission errors as 404).
- Synthetic "local-cluster" via `get('local-cluster')` (bypasses ACL).
- `alert_utils.ts` timestamp / threshold parsing edge cases.
- `directquery_prometheus_backend.ts` `as unknown as T` casts + AM methods swallowing errors.
- `prometheus_metadata_service.ts` cache effectively dead in production (SWR branch unreachable per-request); needs cross-tenant-safe shared cache keyed on principal.
- `alert_utils.ts` plain `Error` throws should use typed error factories.

**Client:**
- `escapeHtml` doesn't escape `/` (OWASP nit).
- `alarms_page.tsx` localStorage write on every `datasources` ref change.
- `monitor_template_wizard` `MOCK_METRICS = []` dead-end.
- Empty `<div />` Suspense fallback (no data-test-subj, no spinner).
- Dead `useAlerts`/`useRules` hooks (zero consumers).
- Stale `api.example.com` in canned AI-analysis text.
- Alerting registered in `DEFAULT_NAV_GROUPS.all` (surfaces in non-observability workspaces).

## Test plan

- [x] Full alerting suite: **239 tests / 41 suites passing** on Node 22.
- [x] `yarn lint:es` — 0 errors (13 pre-existing `any` warnings in files untouched by this change).
- [x] `yarn typecheck` — 0 errors.
- [ ] Manual smoke with concurrent Alert Manager requests from different users / workspaces.
- [ ] Manual smoke of `runbook_url: javascript:...` to confirm XSS fix.
- [ ] Manual smoke of AM config route against upstream returning 403.

## Commit history

- `c53095fd` — initial fixes (concurrency + XSS + error handling)
- `ad1d8c93` — post-audit hardening
- `f877d5c8` — third-pass polish
- `6c9bac5d` — trim speculative fixes after 20-round self-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
