### PR TITLE
Fix flaky trace_analytics_traces Cypress tests

### DIFF
--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -85,7 +85,7 @@ describe('Testing trace view', () => {
     cy.get('.euiTableRow').should('have.length.lessThan', 3); //Replaces wait
     cy.get('[data-test-subj="trace-table-mode-selector"]').click();
     cy.get('.euiSelectableListItem__content').contains('Traces').click();
-    cy.get('.euiDataGridRowCell--firstColumn').eq(0).click();
+    cy.get('.euiDataGridRowCell--firstColumn').eq(0).click({ force: true });
   });
 
   after(() => {
@@ -185,6 +185,7 @@ describe('Testing traces table', () => {
     cy.get('.euiDataGridHeaderCell__content').contains('Percentile in trace group').should('exist');
     cy.get('.euiDataGridHeaderCell__content').contains('Errors').should('exist');
     cy.get('.euiDataGridHeaderCell__content').contains('Last updated').should('exist');
+    cy.get('.euiDataGridRowCell').should('have.length.greaterThan', 0);
     cy.contains('client_pay_order').should('exist');
     cy.get('[data-test-subj="pagination-button-next"]').click();
     cy.contains('client_pay_order').should('not.exist');

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -85,7 +85,7 @@ describe('Testing trace view', () => {
     cy.get('.euiTableRow').should('have.length.lessThan', 3); //Replaces wait
     cy.get('[data-test-subj="trace-table-mode-selector"]').click();
     cy.get('.euiSelectableListItem__content').contains('Traces').click();
-    cy.get('.euiDataGridRowCell--firstColumn').eq(0).click({ force: true });
+    cy.get('.euiDataGridRowCell--firstColumn a.euiLink', { timeout: 60000 }).first().click({ force: true });
   });
 
   after(() => {
@@ -185,7 +185,7 @@ describe('Testing traces table', () => {
     cy.get('.euiDataGridHeaderCell__content').contains('Percentile in trace group').should('exist');
     cy.get('.euiDataGridHeaderCell__content').contains('Errors').should('exist');
     cy.get('.euiDataGridHeaderCell__content').contains('Last updated').should('exist');
-    cy.get('.euiDataGridRowCell').should('have.length.greaterThan', 0);
+    cy.get('.euiDataGridRowCell a.euiLink', { timeout: 60000 }).should('have.length.greaterThan', 0);
     cy.contains('client_pay_order').should('exist');
     cy.get('[data-test-subj="pagination-button-next"]').click();
     cy.contains('client_pay_order').should('not.exist');


### PR DESCRIPTION
Fixes flaky tests in `trace_analytics_traces.spec.js`:

1. **"before each" hook for "Renders data grid, flyout and filters"** — `cy.click()` on data grid cell fails due to `pointer-events: none` on parent div (EUI data grid virtualization). Fix: add `{force: true}`.

2. **"Renders the traces table and verify Table Column, Pagination and Rows Data"** — `cy.contains('client_pay_order')` times out because data grid rows haven't rendered yet. Fix: wait for link elements inside cells to confirm data has loaded.

3. **"Testing trace view" tests (Renders the trace view, Has working breadcrumbs, Renders data grid flyout and filters)** — clicking `.euiDataGridRowCell--firstColumn` with `force: true` clicks the cell wrapper div, not the `<a>` link inside it, so navigation to the trace detail view never happens. Fix: target the actual link element inside the cell.

Signed-off-by: joshuali925-osdbot