### PR TITLE
Fix flaky app_analytics and panels Cypress tests

### DIFF
--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -376,22 +376,17 @@ describe('Viewing application', () => {
 
   it('Opens trace detail flyout when Trace Id is clicked', () => {
     const traceId = '03f9c770db5ee2f1caac0afc36db49ba';
-    // Click the trace link and, if the first click landed on a stale
-    // useMemo-rebuilt handler, click once more. Avoids an unbounded retry loop.
-    const openTraceFlyout = () => {
-      cy.get(`[data-test-subj="trace-link"]:has([title="${traceId}"])`, { timeout: timeoutDelay })
-        .should('be.visible')
-        .click({ force: true });
-      cy.get('body').then(($body) => {
-        if ($body.find('[data-test-subj="traceDetailFlyoutTitle"]').length === 0) {
-          cy.get(`[data-test-subj="trace-link"]:has([title="${traceId}"])`).click({ force: true });
-        }
-      });
-    };
-
     cy.get('[data-test-subj="app-analytics-traceTab"]').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    openTraceFlyout();
+    cy.get(`[data-test-subj="trace-link"]:has([title="${traceId}"])`, { timeout: timeoutDelay })
+      .should('be.visible')
+      .click({ force: true });
+    cy.wait(500);
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test-subj="traceDetailFlyoutTitle"]').length === 0) {
+        cy.get(`[data-test-subj="trace-link"]:has([title="${traceId}"])`).click({ force: true });
+      }
+    });
     cy.get('[data-test-subj="traceDetailFlyoutTitle"]', { timeout: timeoutDelay }).should(
       'be.visible'
     );
@@ -403,7 +398,15 @@ describe('Viewing application', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-test-subj="superDatePickerShowDatesButton"]').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    openTraceFlyout();
+    cy.get(`[data-test-subj="trace-link"]:has([title="${traceId}"])`, { timeout: timeoutDelay })
+      .should('be.visible')
+      .click({ force: true });
+    cy.wait(500);
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test-subj="traceDetailFlyoutTitle"]').length === 0) {
+        cy.get(`[data-test-subj="trace-link"]:has([title="${traceId}"])`).click({ force: true });
+      }
+    });
     cy.get('.panel-title-count', { timeout: timeoutDelay }).contains('(11)').should('exist');
     cy.get('[data-text="Span list"]').click();
     cy.get('[data-test-subj="dataGridRowCell"]', { timeout: timeoutDelay })

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -454,13 +454,12 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         .trigger('mouseover')
         .click({ force: true })
         .focus()
-        .type(PPL_FILTER, { force: true, delay: 50 })
-        .type('{esc}', { force: true });
+        .type(PPL_FILTER, { force: true, delay: 50 });
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')
         .invoke('val')
         .should('contain', 'Munich Airport');
-      cy.wait(1000);
       cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
+      cy.get('.euiButton__text').contains('Refresh').trigger('mouseover').click();
       cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
       cy.get('.xtick').contains('Zurich Airport').should('not.exist');
       cy.get('.xtick').contains('BeatsWest').should('not.exist');

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -454,10 +454,12 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         .trigger('mouseover')
         .click({ force: true })
         .focus()
-        .type(PPL_FILTER, { force: true, delay: 50 });
+        .type(PPL_FILTER, { force: true, delay: 50 })
+        .type('{esc}', { force: true });
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')
         .invoke('val')
         .should('contain', 'Munich Airport');
+      cy.wait(1000);
       cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
       cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
       cy.get('.xtick').contains('Zurich Airport').should('not.exist');


### PR DESCRIPTION
Fix two flaky Cypress tests:

1. **panels: Add ppl filter to panel** — `.xtick` never found after 40s timeout. Root cause: the autocomplete dropdown stays open after typing, and its React `onStateChange` fires asynchronously. When the Apply button is clicked immediately, the `pplFilterValue` React state may not have been committed yet. Fix: press `{esc}` after typing to dismiss the dropdown and commit state, plus `cy.wait(1000)` before Apply.

2. **app_analytics: Opens trace detail flyout when Trace Id is clicked** — `traceDetailFlyoutTitle` never found. Root cause: the synchronous `$body.find()` check runs immediately after `.click()`, before React can render the flyout. Fix: add `cy.wait(500)` before the body check so React has time to process the click handler and mount the flyout.