### PR TITLE
Fix flaky 'Add ppl filter to panel' Cypress test

### DIFF
--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -454,12 +454,13 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         .trigger('mouseover')
         .click({ force: true })
         .focus()
-        .type(PPL_FILTER, { force: true, delay: 50 })
-        .type('{esc}', { force: true });
+        .type(PPL_FILTER, { force: true, delay: 50 });
+      // Blur to commit autocomplete state to React, then wait for dropdown to close
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]').blur();
+      cy.get('.aa-Panel').should('not.exist');
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')
         .invoke('val')
         .should('contain', 'Munich Airport');
-      cy.wait(1000);
       cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
       cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
       cy.get('.xtick').contains('Zurich Airport').should('not.exist');

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -439,30 +439,29 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         cy.get('a.euiLink').contains(this.thePanel.attributes.title).click();
       });
 
+      // Type PPL filter first
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
+        .trigger('mouseover')
+        .click({ force: true })
+        .focus()
+        .type(PPL_FILTER, { force: true, delay: 50 });
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
+        .invoke('val')
+        .should('contain', 'Munich Airport');
+
+      // Now set the time range — this triggers onRefreshFilters with the current pplFilterValue
+      cy.intercept('POST', '**/api/ppl/search').as('pplSearch');
       cy.get('.euiButtonEmpty[data-test-subj="superDatePickerToggleQuickMenuButton"]').click({
         force: true,
       });
       cy.get('[data-test-subj="superDatePickerQuickMenu"')
         .first()
         .within(() => {
-          cy.get('input[aria-label="Time value"]').type('2', { force: true });
+          cy.get('input[aria-label="Time value"]').clear().type('2', { force: true });
           cy.get('select[aria-label="Time unit"]').select('years');
           cy.get('button').contains('Apply').click();
         });
-
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
-        .trigger('mouseover')
-        .click({ force: true })
-        .focus()
-        .type(PPL_FILTER, { force: true, delay: 50 });
-      // Blur to commit autocomplete state to React, then wait for dropdown to close
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]').blur();
-      cy.get('.aa-Panel').should('not.exist');
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
-        .invoke('val')
-        .should('contain', 'Munich Airport');
-      cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
-      cy.get('.euiButton__text').contains('Refresh').trigger('mouseover').click();
+      cy.wait('@pplSearch', { timeout: 30000 });
       cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
       cy.get('.xtick').contains('Zurich Airport').should('not.exist');
       cy.get('.xtick').contains('BeatsWest').should('not.exist');


### PR DESCRIPTION
Fix the flaky 'Add ppl filter to panel' Cypress test by reordering the test steps and adding deterministic waits.

**Root cause**: The test set the time range first (quick menu Apply), then typed the filter, then clicked `superDatePickerApplyTimeButton`. The main date picker button may not reliably fire `onTimeChange` when there are no pending changes (time already applied by quick menu). This means `onRefreshFilters` never gets called with the filter value.

**Fix**:
- Type the PPL filter **before** setting the time range
- The quick menu Apply button always fires `onTimeChange` → `onRefreshFilters` with the current `pplFilterValue` (already set via `handleQueryChange` during typing)
- Use `cy.intercept` + `cy.wait` on the PPL search API to wait for the actual data response before asserting chart content
- Clear the time value input before typing to ensure exact value '2' (not appended to existing default)