### PR TITLE
Fix flaky 'Add ppl filter to panel' cypress test

### DIFF
--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -439,18 +439,29 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         cy.get('a.euiLink').contains(this.thePanel.attributes.title).click();
       });
 
-      // Type PPL filter first
+      // Wait for panel to fully load before interacting
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]', { timeout: 30000 }).should('exist');
+
+      // Type the PPL filter
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')
-        .trigger('mouseover')
         .click({ force: true })
-        .focus()
         .type(PPL_FILTER, { force: true, delay: 50 });
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')
         .invoke('val')
         .should('contain', 'Munich Airport');
 
-      // Now set the time range — this triggers onRefreshFilters with the current pplFilterValue
-      cy.intercept('POST', '**/api/ppl/search').as('pplSearch');
+      // Dismiss autocomplete and ensure React state is committed
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]').blur();
+      cy.wait(500);
+
+      // Intercept only the filtered PPL search (body contains the filter text)
+      cy.intercept('POST', '**/api/ppl/search', (req) => {
+        if (req.body && JSON.stringify(req.body).includes('Munich Airport')) {
+          req.alias = 'filteredPplSearch';
+        }
+      });
+
+      // Set time range — triggers onRefreshFilters which reads pplFilterValue
       cy.get('.euiButtonEmpty[data-test-subj="superDatePickerToggleQuickMenuButton"]').click({
         force: true,
       });
@@ -461,7 +472,7 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
           cy.get('select[aria-label="Time unit"]').select('years');
           cy.get('button').contains('Apply').click();
         });
-      cy.wait('@pplSearch', { timeout: 30000 });
+      cy.wait('@filteredPplSearch', { timeout: 30000 });
       cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
       cy.get('.xtick').contains('Zurich Airport').should('not.exist');
       cy.get('.xtick').contains('BeatsWest').should('not.exist');


### PR DESCRIPTION
## Problem

The 'Add ppl filter to panel' test intermittently fails with:
```
AssertionError: Timed out retrying after 40000ms: Expected to find element: `.xtick`, but never found it.
```

## Root Cause

`cy.wait('@pplSearch')` was catching **stale unfiltered PPL searches** from the initial visualization load (triggered when the panel page renders), not the filtered search triggered by the date picker Apply button. This caused the test to assert `.xtick` before the filtered chart had a chance to render.

Previous fixes (blur, {esc}, reordering) addressed the wrong problem — they assumed `pplFilterValue` wasn't committed to React state. The actual issue was the intercept alias matching the wrong network request.

## Fix

1. **Conditional intercept**: Only alias PPL requests that contain 'Munich Airport' in the body. This ensures `cy.wait('@filteredPplSearch')` waits for the actual filtered search, not a stale unfiltered one.
2. **Blur + 500ms wait**: Dismiss the autocomplete dropdown and allow React to commit the final `pplFilterValue` state update before interacting with the date picker.
3. **Wait for search bar**: Ensure the panel page is fully loaded before interacting with UI elements.

## Testing

The fix addresses the core timing issue rather than adding more arbitrary waits. If the filter value isn't committed, the conditional intercept will timeout with a clear error message (alias never matched) rather than the ambiguous `.xtick` timeout.