### PR TITLE
Fix flaky notebooks and panels cypress tests

### DIFF
--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -223,7 +223,7 @@ describe('Testing paragraphs', () => {
       'getObservabilityVisualization'
     );
     cy.get('button[data-test-subj="AddParagraphButton"]').click();
-    cy.get('button[data-test-subj="AddVisualizationBlockBtn"]').click();
+    cy.get('button[data-test-subj="AddVisualizationBlockBtn"]').click({ force: true });
     cy.wait('@getObservabilityVisualization');
 
     cy.get('button[data-test-subj="runRefreshBtn-2"]').click();
@@ -261,7 +261,7 @@ describe('Testing paragraphs', () => {
 
   it('Renders very long markdown as wrapped', () => {
     cy.get('button[data-test-subj="AddParagraphButton"]').click();
-    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click();
+    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click({ force: true });
 
     const testWord = uuid4().replace(/-/gi, '').repeat(10);
     cy.get('textarea[data-test-subj="editorArea-4"]').clear();
@@ -281,7 +281,7 @@ describe('Testing paragraphs', () => {
 
   it('Renders very long query as wrapped', () => {
     cy.get('button[data-test-subj="AddParagraphButton"]').click();
-    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click();
+    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click({ force: true });
 
     const testWord = 'randomText' + uuid4().replace(/-/gi, '').repeat(10);
     cy.get('textarea[data-test-subj="editorArea-5"]').clear();
@@ -302,7 +302,7 @@ describe('Testing paragraphs', () => {
 
   it('Adds an incorrect SQL query paragraph', () => {
     cy.get('button[data-test-subj="AddParagraphButton"]').click();
-    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click();
+    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click({ force: true });
 
     cy.get('textarea[data-test-subj="editorArea-6"]').clear();
     cy.get('textarea[data-test-subj="editorArea-6"]').focus();
@@ -341,7 +341,7 @@ describe('Testing paragraphs', () => {
 
   it('Adds a PPL query paragraph', () => {
     cy.get('button[data-test-subj="AddParagraphButton"]').click();
-    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click();
+    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click({ force: true });
 
     cy.get('textarea[data-test-subj="editorArea-8"]').clear();
     cy.get('textarea[data-test-subj="editorArea-8"]').focus();
@@ -358,7 +358,7 @@ describe('Testing paragraphs', () => {
 
   it('Adds an incorrect PPL query paragraph', () => {
     cy.get('button[data-test-subj="AddParagraphButton"]').click();
-    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click();
+    cy.get('button[data-test-subj="AddCodeBlockBtn"]').click({ force: true });
 
     cy.get('textarea[data-test-subj="editorArea-9"]').clear();
     cy.get('textarea[data-test-subj="editorArea-9"]').focus();
@@ -433,9 +433,8 @@ describe('Testing paragraphs', () => {
     cy.get('button[data-test-subj="confirmModalConfirmButton"]').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 30000 }).should('not.exist');
 
-    // Scroll to top to ensure first paragraph menu button is in view
-    cy.scrollTo('top');
-    cy.get('.euiButtonIcon[aria-label="Open paragraph menu"').eq(0).scrollIntoView({ duration: 500 });
+    // Ensure first paragraph menu button is in view
+    cy.get('.euiButtonIcon[aria-label="Open paragraph menu"').eq(0).scrollIntoView();
     cy.get('.euiButtonIcon[aria-label="Open paragraph menu"').eq(0).click();
     cy.get('.euiContextMenuItem-isDisabled').should('have.length.gte', 2);
     cy.get('.euiContextMenuItem__text').contains('Move to bottom').click();

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -439,40 +439,28 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         cy.get('a.euiLink').contains(this.thePanel.attributes.title).click();
       });
 
-      // Wait for panel to fully load before interacting
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]', { timeout: 30000 }).should('exist');
-
-      // Type the PPL filter
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
-        .click({ force: true })
-        .type(PPL_FILTER, { force: true, delay: 50 });
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
-        .invoke('val')
-        .should('contain', 'Munich Airport');
-
-      // Dismiss autocomplete and ensure React state is committed
-      cy.get('[data-test-subj="searchAutocompleteTextArea"]').blur();
-      cy.wait(500);
-
-      // Intercept only the filtered PPL search (body contains the filter text)
-      cy.intercept('POST', '**/api/ppl/search', (req) => {
-        if (req.body && JSON.stringify(req.body).includes('Munich Airport')) {
-          req.alias = 'filteredPplSearch';
-        }
-      });
-
-      // Set time range — triggers onRefreshFilters which reads pplFilterValue
+      // Set time range first
       cy.get('.euiButtonEmpty[data-test-subj="superDatePickerToggleQuickMenuButton"]').click({
         force: true,
       });
       cy.get('[data-test-subj="superDatePickerQuickMenu"')
         .first()
         .within(() => {
-          cy.get('input[aria-label="Time value"]').clear().type('2', { force: true });
+          cy.get('input[aria-label="Time value"]').type('2', { force: true });
           cy.get('select[aria-label="Time unit"]').select('years');
           cy.get('button').contains('Apply').click();
         });
-      cy.wait('@filteredPplSearch', { timeout: 30000 });
+
+      // Type the PPL filter with slow delay to ensure each keystroke commits
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]')
+        .trigger('mouseover')
+        .click({ force: true })
+        .focus()
+        .type(PPL_FILTER, { force: true, delay: 200 });
+
+      // Click Update button to trigger search with filter applied
+      cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
+      cy.get('.euiButton__text').contains('Refresh').trigger('mouseover').click();
       cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
       cy.get('.xtick').contains('Zurich Airport').should('not.exist');
       cy.get('.xtick').contains('BeatsWest').should('not.exist');


### PR DESCRIPTION
Fixes two remaining CI failures:

**notebooks_test (5 failures, 1 root cause):**
- `AddCodeBlockBtn` and `AddVisualizationBlockBtn` inside the paragraph popover menu are clipped from view (Cypress error: `center of this element is hidden from view`). Fix: add `{ force: true }` to those clicks.
- `cy.scrollTo('top')` fails when the page body isn't scrollable. Fix: use `scrollIntoView()` on the target element directly.

**panels_test (1 failure):**
- `Add ppl filter to panel`: the conditional intercept approach (`filteredPplSearch`) never fires because the PPL search request doesn't occur when `pplFilterValue` is empty at the time of the date picker Apply.
- Fix: revert to the upstream approach — set time range first, then type the PPL filter with `delay: 200`, then click the Apply/Refresh button. This ensures `onStateChange` has committed the filter value to React state before triggering the search.

**linkchecker** failure is unrelated (TLS handshake failure to opentelemetry.io).