### PR TITLE
Fix notebooks visualization selection and panels duplicate button race

### DIFF
--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -235,7 +235,10 @@ describe('Testing paragraphs', () => {
     cy.get('.euiModalHeader__title').contains('Browse visualizations').should('exist');
     cy.get('input[aria-label="Searchable Visualizations"]')
       .focus()
-      .type('[Flights] Flight Count and Average Ticket Price{enter}');
+      .type('[Flights] Flight Count and Average Ticket Price');
+    cy.get('.euiSelectableListItem')
+      .contains('[Flights] Flight Count and Average Ticket Price')
+      .click();
     cy.get('button[data-test-subj="para-input-select-button"]').click();
     cy.get('button[data-test-subj="runRefreshBtn-2"]').click();
     cy.get('div.visualization').should('exist');

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -143,7 +143,9 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
         cy.get('.euiTableRow').should('have.length', 1);
         selectThePanel();
         openActionsDropdown();
-        cy.get('button[data-test-subj="duplicateContextMenuItem"]').click();
+        cy.get('button[data-test-subj="duplicateContextMenuItem"]')
+          .should('not.be.disabled')
+          .click();
         cy.get('button[data-test-subj="runModalButton"]').click();
         cy.get('[data-test-subj="breadcrumb"]').click({ force: true }); //Duplicate opens the panel, need to return
         cy.get('.euiTableRow').should('have.length', 2);


### PR DESCRIPTION
Fixes 2 cypress test failures:

1. **notebooks_test — 'Adds a dashboards visualization paragraph'**: The test typed a search term + `{enter}` in the EuiSelectable browse modal, but `{enter}` doesn't select an item in EuiSelectable. The `onSelect()` handler requires `opt.checked === 'on'` which only gets set by clicking a row. Fix: click on the visualization row in the list after searching.

2. **panels_test — 'Duplicates a legacy panel'**: The `duplicateContextMenuItem` button was disabled because the checkbox selection state hadn't propagated to React before the dropdown opened. Fix: add `.should('not.be.disabled')` before clicking, which makes Cypress retry until the button is enabled.