### PR TITLE
Fix notebooks visualization paragraph cypress test

### DIFF
--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -236,9 +236,10 @@ describe('Testing paragraphs', () => {
     cy.get('input[aria-label="Searchable Visualizations"]')
       .focus()
       .type('[Flights] Flight Count and Average Ticket Price');
-    cy.get('.euiSelectableListItem')
-      .contains('[Flights] Flight Count and Average Ticket Price')
-      .click();
+    cy.get('.euiSelectableListItem').should('have.length', 1);
+    cy.get('input[aria-label="Searchable Visualizations"]')
+      .type('{downarrow}')
+      .type('{enter}');
     cy.get('button[data-test-subj="para-input-select-button"]').click();
     cy.get('button[data-test-subj="runRefreshBtn-2"]').click();
     cy.get('div.visualization').should('exist');

--- a/.cypress/utils/constants.js
+++ b/.cypress/utils/constants.js
@@ -87,7 +87,7 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
       .focus()
       .type('{selectall}' + endTime, { force: true });
   }
-  if (refresh) cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
+  if (refresh) cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
   cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 };
 


### PR DESCRIPTION
## Fix notebooks visualization paragraph and trace analytics cypress tests

### Notebooks visualization paragraph
The 'Adds a dashboards visualization paragraph' test fails because the visualization browser's `renderOption` wraps each item in an `EuiLink` with `target="_blank"`. Clicking the list item lands on the link, which can interfere with EuiSelectable's selection state.

**Fix:** Use keyboard navigation (ArrowDown+Enter) from the search input to select the filtered item, completely bypassing the link element. Also wait for the search to filter to exactly one result before selecting, preventing race conditions.

### Trace analytics time filter
The 'Testing filters on trace analytics page' `describe` block uses `scrollBehavior: false`, preventing Cypress from auto-scrolling. The `superDatePickerApplyTimeButton` was hidden from view causing a timeout.

**Fix:** Add `{ force: true }` to the apply button click in `setTimeFilter()`, consistent with all other click calls in that function.

Signed-off-by: joshuali925-osdbot