### PR TITLE
Fix flaky 'Add ppl filter to panel' cypress test

### DIFF
--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -449,11 +449,17 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
             },
           },
         });
+        // Navigate away first to ensure full reload (hash-based routing may not
+        // re-render if already on the same panel URL from beforeEach)
+        cy.visit(`${Cypress.env('opensearchDashboards')}/app/home`);
         moveToThePanel(this.thePanel.id);
       });
 
-      // Wait for the unfiltered chart to render first
-      cy.get('.xtick', { timeout: 30000 }).should('exist');
+      // Wait for panel header to confirm page loaded
+      cy.get('[data-test-subj="panelNameHeader"]', { timeout: 30000 }).should('exist');
+
+      // Wait for the unfiltered chart to render
+      cy.get('.xtick', { timeout: 60000 }).should('exist');
 
       // Type the PPL filter
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -433,41 +433,50 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
 
       cy.then(function () {
         addVisualizationsToPanel(this.thePanel, [this.vis1.id]);
-        moveToThePanel(this.thePanel.id);
-        cy.get('[data-test-subj="breadcrumb"]').click({ force: true });
-        cy.get('input[data-test-subj="operationalPanelSearchBar"]')
-          .focus()
-          .type(this.thePanel.attributes.title);
-        cy.get('a.euiLink').contains(this.thePanel.attributes.title).click();
-      });
-
-      // Set time range first
-      cy.get('.euiButtonEmpty[data-test-subj="superDatePickerToggleQuickMenuButton"]').click({
-        force: true,
-      });
-      cy.get('[data-test-subj="superDatePickerQuickMenu"')
-        .first()
-        .within(() => {
-          cy.get('input[aria-label="Time value"]').type('2', { force: true });
-          cy.get('select[aria-label="Time unit"]').select('years');
-          cy.get('button').contains('Apply').click();
+        // Update time range to 2 years via API so the panel loads with wide range
+        cy.request({
+          method: 'PUT',
+          failOnStatusCode: false,
+          url: `api/saved_objects/observability-panel/${this.thePanel.id}`,
+          headers: {
+            'content-type': 'application/json;charset=UTF-8',
+            'osd-xsrf': true,
+          },
+          body: {
+            attributes: {
+              ...this.thePanel.attributes,
+              timeRange: { from: 'now-2y', to: 'now' },
+            },
+          },
         });
+        moveToThePanel(this.thePanel.id);
+      });
 
-      // Type the PPL filter with slow delay to ensure each keystroke commits
+      // Wait for the unfiltered chart to render first
+      cy.get('.xtick', { timeout: 30000 }).should('exist');
+
+      // Type the PPL filter
       cy.get('[data-test-subj="searchAutocompleteTextArea"]')
-        .trigger('mouseover')
         .click({ force: true })
-        .focus()
-        .type(PPL_FILTER, { force: true, delay: 200 });
+        .type(PPL_FILTER, { force: true, delay: 50 })
+        .blur();
 
-      // Click Update button to trigger search with filter applied
+      // Ensure autocomplete dropdown is closed (confirms React state is committed)
+      cy.get('.aa-Panel').should('not.exist');
+
+      // Verify the filter text is in the input before triggering refresh
+      cy.get('[data-test-subj="searchAutocompleteTextArea"]').should('have.value', PPL_FILTER);
+
+      // Trigger refresh via the date picker update button
       cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click({ force: true });
-      cy.get('.euiButton__text').contains('Refresh').trigger('mouseover').click();
-      cy.get('.xtick', { timeout: 40000 }).should('contain', 'Munich Airport');
-      cy.get('.xtick').contains('Zurich Airport').should('not.exist');
-      cy.get('.xtick').contains('BeatsWest').should('not.exist');
-      cy.get('.xtick').contains('Logstash Airways').should('not.exist');
-      cy.get('.xtick').contains('OpenSearch Dashboards Airlines').should('not.exist');
+
+      // Wait for chart to update with filtered data — only Munich Airport should remain
+      cy.get('.xtick', { timeout: 40000 })
+        .should('contain', 'Munich Airport')
+        .and('not.contain', 'Zurich Airport')
+        .and('not.contain', 'BeatsWest')
+        .and('not.contain', 'Logstash Airways')
+        .and('not.contain', 'OpenSearch Dashboards Airlines');
     });
 
     it('Drag and drop a visualization', () => {


### PR DESCRIPTION
## Problem
The `Add ppl filter to panel` test has been persistently failing with:
```
AssertionError: Timed out retrying after 40000ms: Expected to find element: `.xtick`, but never found it.
```

## Root Cause Analysis
Previous approaches (delay typing, blur, conditional intercepts, double button clicks) all failed because they addressed symptoms not root causes. The fundamental issues were:

1. **Unnecessary breadcrumb navigation** added timing complexity — clicking breadcrumb → searching → clicking link introduced state where the page wasn't fully loaded before interactions.
2. **Quick menu time picker interaction** triggered `onRefreshFilters` with empty `pplFilterValue` (before filter was typed), then the subsequent Update button click may have failed to re-trigger due to EUI's `hasChanged` state.
3. **Double button click** (`superDatePickerApplyTimeButton` + `.euiButton__text contains Refresh`) was redundant (same button) and could cause race conditions.
4. **Assertion strategy** used sequential `cy.get('.xtick').contains(...).should('not.exist')` which checked each condition with the default 10s timeout — too short if the chart update was delayed.

## Fix
- Set time range via API (`PUT` saved object) before navigating — eliminates quick menu interaction entirely
- Navigate directly to panel without breadcrumb roundtrip
- Wait for initial unfiltered chart to render (`.xtick` exists) — proves visualization works
- Type filter → blur → assert dropdown closed → verify input value — deterministic state commit
- Single `superDatePickerApplyTimeButton` click to trigger refresh with committed filter
- Chain all assertions on one `cy.get('.xtick', {timeout: 40000})` with `.should().and()` — retries entire set of conditions together within the 40s timeout